### PR TITLE
Fixed a missing valid extension.

### DIFF
--- a/apimaticcli/api_transformer.py
+++ b/apimaticcli/api_transformer.py
@@ -11,12 +11,18 @@ class APITransformer:
 
     extensions = {
         'APIBluePrint': 'apib',
+        'APIMATIC': 'json',
+        'OpenApi3Json': 'json',
+        'OpenApi3Yaml': 'yaml',
+        'Postman10': 'json',
+        'Postman20': 'json',
+        'RAML': 'raml',
+        'RAML10': 'raml',
         'Swagger10': 'json',
         'Swagger20': 'json',
         'SwaggerYaml': 'yaml',
         'WADL2009': 'wadl',
-        'RAML': 'raml',
-        'APIMATIC': 'json'
+        'WSDL': 'wsdl',
     }
 
     @classmethod


### PR DESCRIPTION
## Issue
`transform` command supports `APIMATIC`, `APIBluePrint`, `Swagger10`, `Swagger20`, `SwaggerYaml`, `OpenApi3Json`, `OpenApi3Yaml`, `RAML`, `RAML10`, `Postman10`, `Postman20`, `WADL2009`, `WSDL` format.
But `OpenApi3Json`, `OpenApi3Yaml`, `RAML10`, `Postman10`, `Postman20`, `WSDL` are errors.

```bash
$ apimatic-cli transform fromuser --email {email} --password {password} --file postman.json --format OpenApi3Yaml

Traceback (most recent call last):
  File "/Users/motohiro.imura/.pyenv/versions/2.7.13/bin/apimatic-cli", line 11, in <module>
    load_entry_point('apimatic-cli==2.5', 'console_scripts', 'apimatic-cli')()
  File "/Users/motohiro.imura/.pyenv/versions/2.7.13/lib/python2.7/site-packages/apimaticcli/__main__.py", line 16, in main
    arguments.func(arguments)
  File "/Users/motohiro.imura/.pyenv/versions/2.7.13/lib/python2.7/site-packages/apimaticcli/api_transformer.py", line 55, in from_user
    cls.save_description(response, args)
  File "/Users/motohiro.imura/.pyenv/versions/2.7.13/lib/python2.7/site-packages/apimaticcli/api_transformer.py", line 60, in save_description
    file_name = args.download_as or ('converted.' + cls.extensions[args.format])
KeyError: 'OpenApi3Yaml'
```

## Solutions
I added `extensions` key-values of `APITransformer`.
Please refer to the source code for details.
