### PR TITLE
feat: adds build directory structure to recipe and toc commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
                 "treeify": "^1.1.0",
                 "tslib": "^2.8.1",
                 "unzipper": "^0.12.3",
-                "which": "^5.0.0",
                 "yaml": "^2.8.0"
             },
             "bin": {
@@ -62,7 +61,6 @@
                 "@types/sinon": "^17.0.4",
                 "@types/treeify": "^1.0.3",
                 "@types/unzipper": "^0.10.4",
-                "@types/which": "^3.0.4",
                 "@typescript-eslint/eslint-plugin": "^8.0.0",
                 "@typescript-eslint/parser": "^8.0.0",
                 "chai": "^4.5.0",
@@ -5500,13 +5498,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/which": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
-            "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/ws": {
             "version": "8.5.14",
             "dev": true,
@@ -9893,15 +9884,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/isexe": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-            "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
             "dev": true,
@@ -13864,21 +13846,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/which": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^3.1.1"
-            },
-            "bin": {
-                "node-which": "bin/which.js"
-            },
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/which-boxed-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "prettier": "^2.8.8",
                 "simple-git": "^3.27.0",
                 "striptags": "^3.2.0",
+                "tmp-promise": "^3.0.3",
                 "treeify": "^1.1.0",
                 "tslib": "^2.8.1",
                 "unzipper": "^0.12.3",
@@ -5330,6 +5331,8 @@
         },
         "node_modules/@types/fs-extra": {
             "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13380,6 +13383,7 @@
             "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
             "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tmp": "^0.2.0"
             }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
         "treeify": "^1.1.0",
         "tslib": "^2.8.1",
         "unzipper": "^0.12.3",
-        "which": "^5.0.0",
         "yaml": "^2.8.0"
     },
     "devDependencies": {
@@ -94,7 +93,6 @@
         "@types/sinon": "^17.0.4",
         "@types/treeify": "^1.0.3",
         "@types/unzipper": "^0.10.4",
-        "@types/which": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "chai": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "prettier": "^2.8.8",
         "simple-git": "^3.27.0",
         "striptags": "^3.2.0",
+        "tmp-promise": "^3.0.3",
         "treeify": "^1.1.0",
         "tslib": "^2.8.1",
         "unzipper": "^0.12.3",

--- a/src/actions/portal/generatePortalAction.ts
+++ b/src/actions/portal/generatePortalAction.ts
@@ -28,15 +28,15 @@ export class GeneratePortalAction {
     zipPortal: boolean
   ): Promise<ActionResult> => {
     if (buildDirectory.isEqual(portalDirectory)) {
-      return ActionResult.error("build directory and portal directory cannot be the same.");
+      return ActionResult.error("'build' directory and portal directory cannot be the same.");
     }
 
     if (!(await this.validateBuild(buildDirectory))) {
-      return ActionResult.error("build directory is empty or not valid");
+      return ActionResult.error("'build' directory does not exist, is empty or not valid");
     }
 
     if (!(await this.validatePortal(portalDirectory, force))) {
-      return ActionResult.error("portal directory is empty or not valid");
+      return ActionResult.error("'portal' directory is empty or not valid");
     }
 
     return await withDir(

--- a/src/actions/portal/generatePortalAction.ts
+++ b/src/actions/portal/generatePortalAction.ts
@@ -32,7 +32,7 @@ export class GeneratePortalAction {
     }
 
     if (!(await this.validateBuild(buildDirectory))) {
-      return ActionResult.error("'build' directory does not exist, is empty or not valid");
+      return ActionResult.error("'build' directory does not exist, is empty, or not valid");
     }
 
     if (!(await this.validatePortal(portalDirectory, force))) {

--- a/src/actions/portal/generatePortalAction.ts
+++ b/src/actions/portal/generatePortalAction.ts
@@ -28,7 +28,7 @@ export class GeneratePortalAction {
     zipPortal: boolean
   ): Promise<ActionResult> => {
     if (buildDirectory.isEqual(portalDirectory)) {
-      return ActionResult.error("'build' directory and portal directory cannot be the same.");
+      return ActionResult.error("'build' directory and 'portal' directory cannot be the same.");
     }
 
     if (!(await this.validateBuild(buildDirectory))) {
@@ -36,7 +36,7 @@ export class GeneratePortalAction {
     }
 
     if (!(await this.validatePortal(portalDirectory, force))) {
-      return ActionResult.error("'portal' directory is empty or not valid");
+      return ActionResult.error("'portal' directory is not empty.");
     }
 
     return await withDir(

--- a/src/actions/portal/recipe/new-recipe.ts
+++ b/src/actions/portal/recipe/new-recipe.ts
@@ -28,7 +28,6 @@ export class PortalRecipeAction {
   public async createRecipe(
     buildDirectoryPath: DirectoryPath,
     configDir: string,
-    buildConfigFilePath?: string,
     name?: string
   ): Promise<Result<string, string>> {
     this.prompts.displayWelcomeMessage();
@@ -41,17 +40,9 @@ export class PortalRecipeAction {
       return Result.failure(`Unable to generate API Recipe: ${validateBuildDirectoryPathResult.error!}`);
     }
 
-    const validateBuildConfigFilePathResult = await this.validateBuildConfigFilePath(buildConfigFilePath);
-    if (validateBuildConfigFilePathResult.isFailed()) {
-      return Result.failure(`Unable to generate API Recipe: ${validateBuildConfigFilePathResult}`);
-    }
-
     //TODO: Create a type for the build config and use that here instead of any.
-    const resolvedBuildConfigFilePath = await this.getResolvedBuildConfigFilePath(
-      buildDirectoryPath,
-      buildConfigFilePath
-    );
-    const buildConfigResult = await this.parseBuildConfig(resolvedBuildConfigFilePath);
+    const buildConfigFilePath = await this.getBuildConfigFilePath(buildDirectoryPath);
+    const buildConfigResult = await this.parseBuildConfig(buildConfigFilePath);
     if (buildConfigResult.isFailed()) {
       return Result.failure(`Unable to generate API Recipe: ${buildConfigResult.error!}`);
     }
@@ -87,7 +78,7 @@ export class PortalRecipeAction {
       tocFilePath,
       recipeName,
       recipeFileName,
-      resolvedBuildConfigFilePath,
+      buildConfigFilePath,
       contentFolderPath
     );
 
@@ -190,9 +181,8 @@ export class PortalRecipeAction {
           editor = "vim";
           try {
             await execa(editor, [tempFilePath], { stdio: "inherit" });
-          }
-          catch (error) {
-            // User exiting vim can throw a non-zero exit code leading to exception, ignore it. 
+          } catch (error) {
+            // User exiting vim can throw a non-zero exit code leading to exception, ignore it.
           }
         }
       } else {
@@ -205,13 +195,12 @@ export class PortalRecipeAction {
 
       const fileContent = await fsExtra.readFile(tempFilePath, "utf-8");
       recipe.addContentStep(stepName, stepName, fileContent);
-      
+
       this.prompts.displayStepAddedSuccessfullyMessage();
       return Result.success("Added content step successfully.");
     } catch (error) {
       return Result.failure(`Unable to add content step. Please try again later.`);
-    }
-    finally {
+    } finally {
       await fsExtra.unlink(tempFilePath);
     }
   }
@@ -252,21 +241,14 @@ export class PortalRecipeAction {
     return `$e/${pathPieces.map(encodeURIComponent).join("/")}`;
   }
 
-  private async getResolvedBuildConfigFilePath(
-    buildDirectoryPath: DirectoryPath,
-    buildConfigFilePath?: string
-  ): Promise<string> {
-    if (!buildConfigFilePath) {
-      const files = await fs.promises.readdir(buildDirectoryPath.toString());
-      const buildFileExists = files.find((file) => file === this.BUILD_FILE_NAME);
-      if (!buildFileExists) {
-        return await this.prompts.buildConfigFilePathPrompt(buildDirectoryPath.toString());
-      }
-
-      return path.join(buildDirectoryPath.toString(), this.BUILD_FILE_NAME);
+  private async getBuildConfigFilePath(buildDirectoryPath: DirectoryPath): Promise<string> {
+    const files = await fs.promises.readdir(buildDirectoryPath.toString());
+    const buildFileExists = files.find((file) => file === this.BUILD_FILE_NAME);
+    if (!buildFileExists) {
+      return await this.prompts.buildConfigFilePathPrompt(buildDirectoryPath.toString());
     }
 
-    return buildConfigFilePath;
+    return path.join(buildDirectoryPath.toString(), this.BUILD_FILE_NAME);
   }
 
   //TODO: Create a type for the build config and use that here instead of any.
@@ -298,9 +280,7 @@ export class PortalRecipeAction {
     return false;
   }
 
-  private async getBuildDirectoryStructure(
-    recipeFileName: string
-  ): Promise<DirectoryNode> {
+  private async getBuildDirectoryStructure(recipeFileName: string): Promise<DirectoryNode> {
     return {
       content: {
         "toc.yml : # Contains the API Recipes group with a new page for your API recipe": null

--- a/src/actions/portal/recipe/new-recipe.ts
+++ b/src/actions/portal/recipe/new-recipe.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import fs from "fs";
 import fsExtra from "fs-extra";
-import which from "which";
 import { parse } from "yaml";
 import { TreeObject } from "treeify";
 import { tmpdir } from "os";
@@ -14,6 +13,7 @@ import { PortalRecipeGenerator } from "../../../application/portal/recipe/recipe
 import { SdlParser } from "../../../application/portal/toc/sdl-parser.js";
 import { PortalService } from "../../../infrastructure/services/portal-service.js";
 import { SdlEndpoint } from "../../../types/sdl/sdl.js";
+import { DirectoryPath } from "../../../types/file/directoryPath.js";
 
 export class PortalRecipeAction {
   private readonly prompts: PortalRecipePrompts;
@@ -26,7 +26,7 @@ export class PortalRecipeAction {
   }
 
   public async createRecipe(
-    buildDirectoryPath: string,
+    buildDirectoryPath: DirectoryPath,
     configDir: string,
     buildConfigFilePath?: string,
     name?: string
@@ -109,9 +109,9 @@ export class PortalRecipeAction {
       .join("");
   }
 
-  private async validateBuildDirectoryPath(buildDirectoryPath: string): Promise<Result<string, string>> {
-    if (!(await fsExtra.pathExists(buildDirectoryPath))) {
-      return Result.failure(`Portal build input folder ${buildDirectoryPath} does not exist.`);
+  private async validateBuildDirectoryPath(buildDirectoryPath: DirectoryPath): Promise<Result<string, string>> {
+    if (!(await fsExtra.pathExists(buildDirectoryPath.toString()))) {
+      return Result.failure(`Portal build input folder ${buildDirectoryPath.toString()} does not exist.`);
     }
 
     return Result.success("Portal build input folder path validated successfully.");
@@ -253,17 +253,17 @@ export class PortalRecipeAction {
   }
 
   private async getResolvedBuildConfigFilePath(
-    buildDirectoryPath: string,
+    buildDirectoryPath: DirectoryPath,
     buildConfigFilePath?: string
   ): Promise<string> {
     if (!buildConfigFilePath) {
-      const files = await fs.promises.readdir(buildDirectoryPath);
+      const files = await fs.promises.readdir(buildDirectoryPath.toString());
       const buildFileExists = files.find((file) => file === this.BUILD_FILE_NAME);
       if (!buildFileExists) {
-        return await this.prompts.buildConfigFilePathPrompt(buildDirectoryPath);
+        return await this.prompts.buildConfigFilePathPrompt(buildDirectoryPath.toString());
       }
 
-      return path.join(buildDirectoryPath, this.BUILD_FILE_NAME);
+      return path.join(buildDirectoryPath.toString(), this.BUILD_FILE_NAME);
     }
 
     return buildConfigFilePath;
@@ -357,12 +357,12 @@ export class PortalRecipeAction {
   }
 
   //TODO: Replace type of buildConfig from any to actual BuildConfig type after creating it.
-  private getContentFolderPath(buildConfig: any, buildDirectoryPath: string): string {
+  private getContentFolderPath(buildConfig: any, buildDirectoryPath: DirectoryPath): string {
     const contentFolder = buildConfig.generatePortal?.contentFolder;
     if (contentFolder) {
-      return path.join(buildDirectoryPath, contentFolder);
+      return path.join(buildDirectoryPath.toString(), contentFolder);
     }
 
-    return buildDirectoryPath;
+    return buildDirectoryPath.toString();
   }
 }

--- a/src/actions/portal/recipe/new-recipe.ts
+++ b/src/actions/portal/recipe/new-recipe.ts
@@ -181,7 +181,7 @@ export class PortalRecipeAction {
           editor = "vim";
           try {
             await execa(editor, [tempFilePath], { stdio: "inherit" });
-          } catch (error) {
+          } catch {
             // User exiting vim can throw a non-zero exit code leading to exception, ignore it.
           }
         }

--- a/src/actions/portal/serve.ts
+++ b/src/actions/portal/serve.ts
@@ -38,7 +38,9 @@ export class PortalServeAction {
     const result = await generatePortal(
       new DirectoryPath(paths.sourceDirectoryPath),
       new DirectoryPath(paths.destinationDirectoryPath),
-      true, false);
+      true,
+      false
+    );
 
     return result.mapAll<Promise<Result<string, string>>>(
       async () => {
@@ -51,8 +53,6 @@ export class PortalServeAction {
         if (startServerResult.isFailed()) {
           return Result.failure(startServerResult.error!);
         }
-
-        this.prompts.displayOutroMessage(flags.port);
 
         return Result.success(`Portal was successfully served.`);
       },

--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -8,6 +8,7 @@ import { TocStructureGenerator } from "../../../application/portal/toc/toc-struc
 import { TocContentParser } from "../../../application/portal/toc/toc-content-parser.js";
 import { TocEndpoint, TocGroup, TocModel } from "../../../types/toc/toc.js";
 import { PortalService } from "../../../infrastructure/services/portal-service.js";
+import { DirectoryPath } from "../../../types/file/directoryPath.js";
 
 const DEFAULT_TOC_FILENAME = "toc.yml";
 const APIMATIC_BUILD_FILENAME = "APIMATIC-BUILD.json";
@@ -26,15 +27,15 @@ export class PortalNewTocAction {
   }
 
   async createToc(
-    workingDirectory: string,
+    buildDirectory: DirectoryPath,
     configDir: string,
-    destination?: string,
+    tocDirectory?: DirectoryPath,
     force: boolean = false,
     expandEndpoints: boolean = false,
     expandModels: boolean = false
   ): Promise<Result<string, string>> {
     try {
-      const tocDir = await this.getDestinationPath(workingDirectory, destination);
+      const tocDir = await this.getDestinationPath(buildDirectory, tocDirectory);
       const tocPath = path.join(tocDir, DEFAULT_TOC_FILENAME);
       const tocCheckResult = await this.handleExistingToc(tocPath, force);
       if (!tocCheckResult.isSuccess()) {
@@ -42,13 +43,13 @@ export class PortalNewTocAction {
       }
 
       const { endpointGroups, models } = await this.extractSdlComponents(
-        workingDirectory,
+        buildDirectory,
         configDir,
         expandEndpoints,
         expandModels
       );
 
-      const contentGroups = await this.extractContentGroups(workingDirectory);
+      const contentGroups = await this.extractContentGroups(buildDirectory);
 
       const toc = this.tocGenerator.createTocStructure(
         endpointGroups,
@@ -82,7 +83,7 @@ export class PortalNewTocAction {
   }
 
   private async extractSdlComponents(
-    workingDirectory: string,
+    buildDirectory: DirectoryPath,
     configDir: string,
     expandEndpoints: boolean,
     expandModels: boolean
@@ -92,7 +93,7 @@ export class PortalNewTocAction {
     }
 
     this.prompts.startProgressIndicatorWithMessage("Extracting endpoints and/or models from the API specification...");
-    const specFolderPath = await this.getSpecFolderPath(workingDirectory);
+    const specFolderPath = await this.getSpecFolderPath(buildDirectory);
 
     if (!(await fsExtra.pathExists(specFolderPath))) {
       this.prompts.stopProgressIndicatorWithMessage(`⚠️ Could not find the specification folder at: ${specFolderPath}`);
@@ -100,7 +101,7 @@ export class PortalNewTocAction {
       return { endpointGroups: new Map(), models: [] };
     }
 
-    const sdlResult = await this.sdlParser.getTocComponentsFromSdl(specFolderPath, workingDirectory, configDir);
+    const sdlResult = await this.sdlParser.getTocComponentsFromSdl(specFolderPath, buildDirectory, configDir);
 
     if (!sdlResult.isSuccess()) {
       this.prompts.stopProgressIndicatorWithMessage(`⚠️ ${sdlResult.error!}`);
@@ -114,8 +115,8 @@ export class PortalNewTocAction {
     return sdlResult.value!;
   }
 
-  private async extractContentGroups(workingDirectory: string): Promise<TocGroup[]> {
-    const contentFolderPath = await this.getContentFolderPath(workingDirectory);
+  private async extractContentGroups(buildDirectory: DirectoryPath): Promise<TocGroup[]> {
+    const contentFolderPath = await this.getContentFolderPath(buildDirectory);
 
     if (!(await fsExtra.pathExists(contentFolderPath))) {
       this.prompts.displayInfo(`⚠️ Could not locate the content folder at: ${contentFolderPath}`);
@@ -126,12 +127,12 @@ export class PortalNewTocAction {
     return await this.contentParser.parseContentFolder(contentFolderPath, contentFolderPath);
   }
 
-  private async getDestinationPath(workingDirectory: string, providedDestination?: string): Promise<string> {
-    if (providedDestination === undefined) {
-      const inferredDestination = await this.getContentFolderPath(workingDirectory);
+  private async getDestinationPath(buildDirectory: DirectoryPath, providedTocDirectory?: DirectoryPath): Promise<string> {
+    if (providedTocDirectory === undefined) {
+      const inferredDestination = await this.getContentFolderPath(buildDirectory);
       return inferredDestination;
     }
-    return providedDestination;
+    return providedTocDirectory.toString();
   }
 
   private async checkExistingToc(tocPath: string, force: boolean): Promise<boolean> {
@@ -141,9 +142,9 @@ export class PortalNewTocAction {
     return true;
   }
 
-  private async getContentFolderPath(workingDirectory: string): Promise<string> {
-    const buildFilePath = path.join(workingDirectory, APIMATIC_BUILD_FILENAME);
-    const defaultContentFolder = path.join(workingDirectory, "content");
+  private async getContentFolderPath(buildDirectory: DirectoryPath): Promise<string> {
+    const buildFilePath = path.join(buildDirectory.toString(), APIMATIC_BUILD_FILENAME);
+    const defaultContentFolder = path.join(buildDirectory.toString(), "content");
 
     if (!(await fsExtra.pathExists(buildFilePath))) {
       return defaultContentFolder;
@@ -155,15 +156,15 @@ export class PortalNewTocAction {
       if (buildConfig.generatePortal?.contentFolder == null) {
         return defaultContentFolder;
       }
-      return path.join(workingDirectory, buildConfig.generatePortal.contentFolder, "content");
+      return path.join(buildDirectory.toString(), buildConfig.generatePortal.contentFolder, "content");
     } catch {
       return defaultContentFolder;
     }
   }
 
-  private async getSpecFolderPath(workingDirectory: string): Promise<string> {
-    const buildFilePath = path.join(workingDirectory, APIMATIC_BUILD_FILENAME);
-    const defaultSpecFolder = path.join(workingDirectory, "spec");
+  private async getSpecFolderPath(buildDirectory: DirectoryPath): Promise<string> {
+    const buildFilePath = path.join(buildDirectory.toString(), APIMATIC_BUILD_FILENAME);
+    const defaultSpecFolder = path.join(buildDirectory.toString(), "spec");
 
     if (!(await fsExtra.pathExists(buildFilePath))) {
       return defaultSpecFolder;
@@ -175,7 +176,7 @@ export class PortalNewTocAction {
       if (buildConfig.generatePortal?.apiSpecPath == null) {
         return defaultSpecFolder;
       }
-      return path.join(workingDirectory, buildConfig.generatePortal.apiSpecPath);
+      return path.join(buildDirectory.toString(), buildConfig.generatePortal.apiSpecPath);
     } catch {
       return defaultSpecFolder;
     }

--- a/src/application/portal/serve/portal-watcher.ts
+++ b/src/application/portal/serve/portal-watcher.ts
@@ -9,7 +9,6 @@ import { DirectoryPath } from "../../../types/file/directoryPath.js";
 import { ActionResult } from "../../../actions/actionResult.js";
 
 export class PortalWatcher {
-
   public async watchAndRegeneratePortalOnChange(
     paths: ServePaths,
     ignoredPaths: string[],
@@ -89,8 +88,12 @@ export class PortalWatcher {
     if (!eventQueue.has(eventId)) {
       return;
     }
-    const result = await generatePortal(new DirectoryPath(paths.sourceDirectoryPath), new DirectoryPath(paths.destinationDirectoryPath), true, false);
-    result.map(error => console.log(error));
+    const result = await generatePortal(
+      new DirectoryPath(paths.sourceDirectoryPath),
+      new DirectoryPath(paths.destinationDirectoryPath),
+      true,
+      false
+    );
+    result.map((error) => console.log(error));
   }
-
 }

--- a/src/application/portal/toc/sdl-parser.ts
+++ b/src/application/portal/toc/sdl-parser.ts
@@ -4,18 +4,19 @@ import { zipPortalSource, deleteFile } from "../../../utils/utils.js";
 import { TocEndpoint, TocModel } from "../../../types/toc/toc.js";
 import { Result } from "../../../types/common/result.js";
 import { Sdl, SdlEndpoint, SdlModel } from "../../../types/sdl/sdl.js";
+import { DirectoryPath } from "../../../types/file/directoryPath.js";
 
 export class SdlParser {
   constructor(private readonly portalService: PortalService) {}
 
   public async getTocComponentsFromSdl(
     specFolderPath: string,
-    workingDirectory: string,
+    buildDirectory: DirectoryPath,
     configDir: string
   ): Promise<Result<{ endpointGroups: Map<string, TocEndpoint[]>; models: TocModel[] }, string>> {
     const sourceSpecInputZipFilePath = await zipPortalSource(
       specFolderPath,
-      path.join(workingDirectory, ".spec_source.zip")
+      path.join(buildDirectory.toString(), ".spec_source.zip")
     );
 
     try {

--- a/src/commands/api/transform.ts
+++ b/src/commands/api/transform.ts
@@ -16,12 +16,8 @@ export default class Transform extends Command {
   static description = `Transform API specifications from one format to another. Supports [10+ different formats](https://www.apimatic.io/transformer/#supported-formats) including OpenApi/Swagger, RAML, WSDL and Postman Collections.`;
 
   static examples = [
-    `$ apimatic api:transform --format="OpenApi3Json" --file="./specs/sample.json" --destination="D:/"
-Success! Your transformed file is located at D:/Transformed_OpenApi3Json.json
-`,
-    `$ apimatic api:transform --format=RAML --url="https://petstore.swagger.io/v2/swagger.json"  --destination="D:/"
-Success! Your transformed file is located at D:/swagger_raml.yaml
-`
+    `$ apimatic api:transform --format="OpenApi3Json" --file="./specs/sample.json" --destination="D:/"`,
+    `$ apimatic api:transform --format=RAML --url="https://petstore.swagger.io/v2/swagger.json"  --destination="D:/"`
   ];
 
   static flags = {

--- a/src/commands/api/validate.ts
+++ b/src/commands/api/validate.ts
@@ -13,12 +13,8 @@ export default class Validate extends Command {
   static description = "Validate the syntactic and semantic correctness of an API specification";
 
   static examples = [
-    `$ apimatic api:validate --file="./specs/sample.json"
-Specification file provided is valid
-`,
-    `$ apimatic api:validate --url=https://petstore.swagger.io/v2/swagger.json
-Specification file provided is valid
-`
+    `$ apimatic api:validate --file="./specs/sample.json"`,
+    `$ apimatic api:validate --url=https://petstore.swagger.io/v2/swagger.json`
   ];
 
   static flags = {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -32,11 +32,11 @@ Authentication key successfully set`
       if (storedAuthInfo && storedAuthInfo.authKey) {
         if (storedAuthInfo.email) {
           return this.log(
-            `You are already logged in as '${storedAuthInfo.email}'. Use auth:logout to logout before logging in again.`
+            `You are already logged in as '${storedAuthInfo.email}'. Use 'auth:logout' to logout before logging in again.`
           );
         }
         return this.log(
-            `You are already logged in with authentication key. Use auth:logout to logout before logging in again.`
+            `You are already logged in with authentication key. Use 'auth:logout' to logout before logging in again.`
           );
       }
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -8,16 +8,7 @@ import { getAuthInfo } from "../../client-utils/auth-manager.js";
 export default class Login extends Command {
   static description = "Login using your APIMatic credentials or an API Key";
 
-  static examples = [
-    `$ apimatic auth:login
-Enter your registered email: apimatic-user@gmail.com
-Please enter your password: *********
-
-You have successfully logged into APIMatic
-`,
-    `$ apimatic auth:login --auth-key=xxxxxx
-Authentication key successfully set`
-  ];
+  static examples = [`$ apimatic auth:login`, `$ apimatic auth:login --auth-key=xxxxxx`];
 
   static flags = {
     "auth-key": Flags.string({ default: "", description: "Set authentication key for all commands" })
@@ -36,8 +27,8 @@ Authentication key successfully set`
           );
         }
         return this.log(
-            `You are already logged in with authentication key. Use 'auth:logout' to logout before logging in again.`
-          );
+          `You are already logged in with authentication key. Use 'auth:logout' to logout before logging in again.`
+        );
       }
 
       const client: SDKClient = SDKClient.getInstance();

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -5,11 +5,7 @@ import { SDKClient } from "../../client-utils/sdk-client.js";
 export default class Login extends Command {
   static description = "Clear local login credentials";
 
-  static examples = [
-    `$ apimatic auth:logout
-Logged out
-`
-  ];
+  static examples = [`$ apimatic auth:logout`];
 
   async run() {
     try {

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -5,11 +5,7 @@ import { SDKClient } from "../../client-utils/sdk-client.js";
 export default class Status extends Command {
   static description = "View current authentication state";
 
-  static examples = [
-    `$ apimatic auth:status
-Currently logged in as apimatic-client@gmail.com
-`
-  ];
+  static examples = [`$ apimatic auth:status`];
 
   async run() {
     try {

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -1,6 +1,7 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Flags, Config } from "@oclif/core";
 import { DirectoryPath } from "../../types/file/directoryPath.js";
 import { GeneratePortalAction } from "../../actions/portal/generatePortalAction.js";
+import { PortalGeneratePrompts } from "../../prompts/portal/generate.js";
 
 const DEFAULT_WORKING_DIRECTORY = "./";
 
@@ -10,10 +11,11 @@ export class PortalGenerate extends Command {
 
   static flags = {
     folder: Flags.string({
-      description: "[default: ./] Path to the parent directory containing the build folder, which includes API specifications and configuration files."
+      description:
+        "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
-      description: "[default: ./portal] path where the portal will be downloaded",
+      description: "[default: ./portal] path where the portal will be downloaded"
     }),
     force: Flags.boolean({
       char: "f",
@@ -22,28 +24,25 @@ export class PortalGenerate extends Command {
     }),
     zip: Flags.boolean({
       default: false,
-      description: "download the generated portal as a .zip archive",
+      description: "download the generated portal as a .zip archive"
     }),
     "auth-key": Flags.string({
       description: "override current authentication state with an authentication key"
     })
   };
 
-  static examples = [
-    `$ apimatic portal:generate --folder="./portal/" --destination="D:/"
-Your portal has been generated at D:/
-`
-  ];
+  static examples = [`$ apimatic portal:generate --folder="./" --destination="./portal"`];
+
+  private readonly prompts: PortalGeneratePrompts;
+
+  constructor(argv: string[], config: Config) {
+    super(argv, config);
+    this.prompts = new PortalGeneratePrompts();
+  }
 
   async run(): Promise<void> {
     const {
-      flags: {
-        folder,
-        destination,
-        force,
-        zip: zipPortal,
-        'auth-key': authKey
-      }
+      flags: { folder, destination, force, zip: zipPortal, "auth-key": authKey }
     } = await this.parse(PortalGenerate);
 
     const workingDirectory = new DirectoryPath(folder ?? DEFAULT_WORKING_DIRECTORY);
@@ -52,7 +51,10 @@ Your portal has been generated at D:/
 
     const action = new GeneratePortalAction(this.getConfigDir(), authKey);
     const result = await action.execute(buildDirectory, portalDirectory, force, zipPortal);
-    result.map((message) =>  this.error(message));
+    result.mapAll(
+      () => this.prompts.displayOutroMessage(portalDirectory.toString()),
+      (message) => this.prompts.logError(message)
+    );
   }
 
   private getConfigDir = () => {

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -15,7 +15,7 @@ export class PortalGenerate extends Command {
         "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
-      description: "[default: ./portal] path where the portal will be downloaded"
+      description: "[default: ./portal] path where the portal will be generated."
     }),
     force: Flags.boolean({
       char: "f",

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -31,7 +31,7 @@ export class PortalGenerate extends Command {
     })
   };
 
-  static examples = [`$ apimatic portal:generate --folder="./" --destination="./portal"`];
+  static examples = [`$ apimatic portal:generate`, `$ apimatic portal:generate --folder="./" --destination="./portal"`];
 
   private readonly prompts: PortalGeneratePrompts;
 

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -15,7 +15,7 @@ export class PortalGenerate extends Command {
         "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
-      description: "[default: ./portal] path where the portal will be generated."
+      description: "[default: <folder>/portal] path where the portal will be generated."
     }),
     force: Flags.boolean({
       char: "f",

--- a/src/commands/portal/quickstart.ts
+++ b/src/commands/portal/quickstart.ts
@@ -111,21 +111,24 @@ export default class PortalQuickstart extends Command {
 
       const languages = await prompts.sdkLanguagesPrompt();
 
-      const workingDirectory = await this.getWorkingDirectory(prompts, controller, specFile, apiValidationSummary, languages);
-
+      const workingDirectory = await this.getWorkingDirectory(
+        prompts,
+        controller,
+        specFile,
+        apiValidationSummary,
+        languages
+      );
 
       const portalServePrompts = new PortalServePrompts();
-      const portalServeAction = new PortalServeAction(portalServePrompts, new ServeHandler(), new PortalService())
+      const portalServeAction = new PortalServeAction(portalServePrompts, new ServeHandler(), new PortalService());
 
       //TODO: This needs to be moved within the action. Port should not be initialized again here.
       const port = await this.getServerPort(3000);
 
       const buildDirectory = new DirectoryPath(workingDirectory, "build");
-      const portalDirectory =  new DirectoryPath(workingDirectory,"portal");
-
+      const portalDirectory = new DirectoryPath(workingDirectory, "portal");
 
       const generatePortalAction = new GeneratePortalAction(new DirectoryPath(this.config.configDir), null);
-      //const generatePortal = () => generatePortalAction.execute(buildDirectory, portalDirectory, true, false);
 
       const serveFlags: ServeFlags = {
         folder: buildDirectory.toString(),
@@ -133,16 +136,21 @@ export default class PortalQuickstart extends Command {
         port: port,
         open: true,
         "no-reload": false,
-        ignore: '',
+        ignore: "",
         "auth-key": undefined
       };
 
       const serverPaths: ServePaths = {
-        sourceDirectoryPath : buildDirectory.toString(),
+        sourceDirectoryPath: buildDirectory.toString(),
         destinationDirectoryPath: portalDirectory.toString()
       };
 
-      const servePortalResult = await portalServeAction.servePortal(serveFlags, serverPaths, generatePortalAction.execute);
+      const servePortalResult = await portalServeAction.servePortal(
+        serveFlags,
+        serverPaths,
+        generatePortalAction.execute
+      );
+      
       if (servePortalResult.isFailed()) {
         portalServePrompts.logError(getMessageInRedColor(servePortalResult.error!));
         return;

--- a/src/commands/portal/quickstart.ts
+++ b/src/commands/portal/quickstart.ts
@@ -1,3 +1,4 @@
+import getPort from "get-port";
 import { Command } from "@oclif/core";
 import { ApiValidationExternalApisController, ApiValidationSummary, Client } from "@apimatic/sdk";
 import { SDKClient } from "../../client-utils/sdk-client.js";
@@ -12,7 +13,6 @@ import { PortalService } from "../../infrastructure/services/portal-service.js";
 import { PortalServePrompts } from "../../prompts/portal/serve.js";
 import { GeneratePortalAction } from "../../actions/portal/generatePortalAction.js";
 import { ServeFlags, ServePaths } from "../../types/portal/serve.js";
-import getPort from "get-port";
 
 export default class PortalQuickstart extends Command {
   static description = "Create your first API Portal using APIMatic's Docs as Code offering.";
@@ -161,7 +161,7 @@ export default class PortalQuickstart extends Command {
         return;
       }
 
-      prompts.displayOutroMessage(workingDirectory);
+      prompts.displayOutroMessage(buildDirectory.toString());
     } catch (error) {
       this.error(getMessageInRedColor(error instanceof Error ? error.message : String(error)));
     }

--- a/src/commands/portal/recipe/new.ts
+++ b/src/commands/portal/recipe/new.ts
@@ -23,10 +23,6 @@ Generated recipe has been added to build directory at: C:/build-folder/`
     folder: Flags.string({
       description:
         "[default: ./] Path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
-    }),
-    "build-config": Flags.string({
-      description:
-        "path to the 'APIMATIC-BUILD.json' file. Defaults to the 'APIMATIC-BUILD.json' file in the build directory if not provided."
     })
   };
 
@@ -41,7 +37,6 @@ Generated recipe has been added to build directory at: C:/build-folder/`
     const createRecipeResult = await portalRecipeAction.createRecipe(
       buildDirectory,
       this.config.configDir,
-      flags["build-config"],
       flags.name
     );
     if (createRecipeResult.isFailed()) {

--- a/src/commands/portal/recipe/new.ts
+++ b/src/commands/portal/recipe/new.ts
@@ -15,7 +15,7 @@ export default class PortalRecipeNew extends Command {
   static override examples = [
     `$ apimatic portal:recipe:new
 Generated recipe has been added to build directory at: C:/`,
-    `$ apimatic portal:recipe:new --name="My API Recipe" --folder="./build-folder" --build-config-file="./build-folder/APIMATIC-BUILD.json"
+    `$ apimatic portal:recipe:new --name="My API Recipe" --folder="./build-folder"
 Generated recipe has been added to build directory at: C:/build-folder/`
   ];
   static override flags = {

--- a/src/commands/portal/recipe/new.ts
+++ b/src/commands/portal/recipe/new.ts
@@ -13,10 +13,8 @@ export default class PortalRecipeNew extends Command {
     "To learn more about API Recipes, visit: https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-portal/api-recipes";
 
   static override examples = [
-    `$ apimatic portal:recipe:new
-Generated recipe has been added to build directory at: C:/`,
-    `$ apimatic portal:recipe:new --name="My API Recipe" --folder="./build-folder"
-Generated recipe has been added to build directory at: C:/build-folder/`
+    `$ apimatic portal:recipe:new`,
+    `$ apimatic portal:recipe:new --name="My API Recipe" --folder="./build-folder"`
   ];
   static override flags = {
     name: Flags.string({ description: "name for the recipe" }),

--- a/src/commands/portal/recipe/new.ts
+++ b/src/commands/portal/recipe/new.ts
@@ -22,11 +22,11 @@ Generated recipe has been added to build directory at: C:/build-folder/`
     name: Flags.string({ description: "name for the recipe" }),
     folder: Flags.string({
       description:
-        "[default: ./] Path to the parent directory containing the build folder, which includes API specifications and configuration files."
+        "[default: ./] Path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     "build-config": Flags.string({
       description:
-        "path to the APIMATIC-BUILD.json file. Defaults to the APIMATIC-BUILD.json file in the build directory if not provided."
+        "path to the 'APIMATIC-BUILD.json' file. Defaults to the 'APIMATIC-BUILD.json' file in the build directory if not provided."
     })
   };
 

--- a/src/commands/portal/recipe/new.ts
+++ b/src/commands/portal/recipe/new.ts
@@ -1,43 +1,45 @@
-import * as path from "path";
 import { Command, Flags } from "@oclif/core";
 import { PortalRecipeAction } from "../../../actions/portal/recipe/new-recipe.js";
 import { PortalRecipePrompts } from "../../../prompts/portal/recipe/new-recipe.js";
 import { getMessageInRedColor } from "../../../utils/utils.js";
+import { DirectoryPath } from "../../../types/file/directoryPath.js";
 
-const DEFAULT_FOLDER = process.cwd();
-export default class PortalNewRecipe extends Command {
+const DEFAULT_WORKING_DIRECTORY = "./";
+
+export default class PortalRecipeNew extends Command {
   static override summary = "Generate an API Recipe for a static API Documentation portal.";
 
-  static override description = "To learn more about API Recipes, visit: https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-portal/api-recipes";
+  static override description =
+    "To learn more about API Recipes, visit: https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-portal/api-recipes";
 
   static override examples = [
-    `$ apimatic portal:recipe:new --name="My API Recipe" --folder="./build-folder" --build-config-file="./build-folder/APIMATIC-BUILD.json"
-Generated recipe has been added to build directory at: C:/build-folder/`,
     `$ apimatic portal:recipe:new
-Generated recipe has been added to build directory at: C:/`
+Generated recipe has been added to build directory at: C:/`,
+    `$ apimatic portal:recipe:new --name="My API Recipe" --folder="./build-folder" --build-config-file="./build-folder/APIMATIC-BUILD.json"
+Generated recipe has been added to build directory at: C:/build-folder/`
   ];
   static override flags = {
     name: Flags.string({ description: "name for the recipe" }),
     folder: Flags.string({
-      parse: async (input: string) => path.resolve(input),
       description:
-        "path to the build directory containing the specs folder, content folder, and the build config file. Defaults to the current working directory if not provided.",
-      default: DEFAULT_FOLDER
+        "[default: ./] Path to the parent directory containing the build folder, which includes API specifications and configuration files."
     }),
     "build-config": Flags.string({
-      parse: async (input: string) => path.resolve(input),
       description:
         "path to the APIMATIC-BUILD.json file. Defaults to the APIMATIC-BUILD.json file in the build directory if not provided."
     })
   };
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(PortalNewRecipe);
+    const { flags } = await this.parse(PortalRecipeNew);
     const portalRecipeAction = new PortalRecipeAction();
     const portalRecipePrompts = new PortalRecipePrompts();
 
+    const workingDirectory = new DirectoryPath(flags.folder ?? DEFAULT_WORKING_DIRECTORY);
+    const buildDirectory = flags.folder ? new DirectoryPath(flags.folder, "build") : workingDirectory.join("build");
+
     const createRecipeResult = await portalRecipeAction.createRecipe(
-      flags.folder,
+      buildDirectory,
       this.config.configDir,
       flags["build-config"],
       flags.name

--- a/src/commands/portal/serve.ts
+++ b/src/commands/portal/serve.ts
@@ -85,6 +85,7 @@ export default class PortalServe extends Command {
     };
 
     const servePortalResult = await portalServeAction.servePortal(serveFlags, serverPaths, generatePortalAction.execute);
+    //TODO: Convert below statements to result.mapAll after changing servePortalResult to ActionResult.
     if (servePortalResult.isFailed()) {
       portalServePrompts.logError(getMessageInRedColor(servePortalResult.error!));
     }
@@ -93,7 +94,9 @@ export default class PortalServe extends Command {
       portalServePrompts.logError(getMessageInRedColor(servePortalResult.value!));
     }
 
-    this.prompts.displayOutroMessage(buildDirectory.toString(), portalDirectory.toString(), port, flags["no-reload"]);
+    if (servePortalResult.isSuccess()) {
+      this.prompts.displayOutroMessage(buildDirectory.toString(), portalDirectory.toString(), port, flags["no-reload"]);
+    }
   }
 
   private async getServerPort(port: number | undefined): Promise<number> {

--- a/src/commands/portal/serve.ts
+++ b/src/commands/portal/serve.ts
@@ -20,10 +20,11 @@ export default class PortalServe extends Command {
       description: "[default: 3000] port to serve the portal."
     }),
     folder: Flags.string({
-      description: "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
+      description:
+        "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
-      description: "[default: <folder>/portal] path where the portal will be generated.",
+      description: "[default: <folder>/portal] path where the portal will be generated."
     }),
     open: Flags.boolean({
       char: "o",
@@ -47,18 +48,19 @@ export default class PortalServe extends Command {
   private readonly prompts: PortalServePrompts;
 
   constructor(argv: string[], config: Config) {
-      super(argv, config);
-      this.prompts = new PortalServePrompts();
-    }
+    super(argv, config);
+    this.prompts = new PortalServePrompts();
+  }
 
   static examples = [
+    "$ apimatic portal:serve",
     '$ apimatic portal:serve --folder="./" --destination="./portal" --port=3000 --open --no-reload'
   ];
 
   public async run() {
     const { flags } = await this.parse(PortalServe);
     const portalServePrompts = new PortalServePrompts();
-    const portalServeAction = new PortalServeAction(portalServePrompts, new ServeHandler(), new PortalService())
+    const portalServeAction = new PortalServeAction(portalServePrompts, new ServeHandler(), new PortalService());
 
     //TODO: This needs to be moved within the action. Port should not be initialized again here.
     const port = await this.getServerPort(flags.port);
@@ -77,10 +79,10 @@ export default class PortalServe extends Command {
       open: flags.open,
       "no-reload": flags["no-reload"],
       ignore: flags.ignore
-    }
+    };
 
     const servePaths: ServePaths = {
-      sourceDirectoryPath : buildDirectory.toString(),
+      sourceDirectoryPath: buildDirectory.toString(),
       destinationDirectoryPath: portalDirectory.toString()
     };
 

--- a/src/commands/portal/serve.ts
+++ b/src/commands/portal/serve.ts
@@ -17,13 +17,13 @@ export default class PortalServe extends Command {
   static flags = {
     port: Flags.integer({
       char: "p",
-      description: "Port to serve the portal."
+      description: "[default: 3000] port to serve the portal."
     }),
     folder: Flags.string({
       description: "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
-      description: "[default: ./portal] path where the portal will be downloaded",
+      description: "[default: ./portal] path where the portal will be generated.",
     }),
     open: Flags.boolean({
       char: "o",
@@ -79,12 +79,12 @@ export default class PortalServe extends Command {
       ignore: flags.ignore
     }
 
-    const serverPaths: ServePaths = {
+    const servePaths: ServePaths = {
       sourceDirectoryPath : buildDirectory.toString(),
       destinationDirectoryPath: portalDirectory.toString()
     };
 
-    const servePortalResult = await portalServeAction.servePortal(serveFlags, serverPaths, generatePortalAction.execute);
+    const servePortalResult = await portalServeAction.servePortal(serveFlags, servePaths, generatePortalAction.execute);
     //TODO: Convert below statements to result.mapAll after changing servePortalResult to ActionResult.
     if (servePortalResult.isFailed()) {
       portalServePrompts.logError(getMessageInRedColor(servePortalResult.error!));

--- a/src/commands/portal/serve.ts
+++ b/src/commands/portal/serve.ts
@@ -20,7 +20,7 @@ export default class PortalServe extends Command {
       description: "Port to serve the portal."
     }),
     folder: Flags.string({
-      description: "[default: ./] Path to the parent directory containing the build folder, which includes API specifications and configuration files."
+      description: "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
       description: "[default: ./portal] path where the portal will be downloaded",
@@ -52,7 +52,7 @@ export default class PortalServe extends Command {
     }
 
   static examples = [
-    '$ apimatic portal:serve --folder="./" --destination="./generated_portal" --port=3000 --open --no-reload'
+    '$ apimatic portal:serve --folder="./" --destination="./portal" --port=3000 --open --no-reload'
   ];
 
   public async run() {
@@ -67,9 +67,7 @@ export default class PortalServe extends Command {
     const buildDirectory = flags.folder ? new DirectoryPath(flags.folder, "build") : workingDirectory.join("build");
     const portalDirectory = flags.destination ? new DirectoryPath(flags.destination) : workingDirectory.join("portal");
 
-
     const generatePortalAction = new GeneratePortalAction(new DirectoryPath(this.config.configDir), flags["auth-key"]);
-    //const generatePortal = () => generatePortalAction.execute(buildDirectory, portalDirectory, true, false);
 
     const serveFlags: ServeFlags = {
       folder: buildDirectory.toString(),
@@ -94,6 +92,8 @@ export default class PortalServe extends Command {
     if (servePortalResult.isCancelled()) {
       portalServePrompts.logError(getMessageInRedColor(servePortalResult.value!));
     }
+
+    this.prompts.displayOutroMessage(buildDirectory.toString(), portalDirectory.toString(), port, flags["no-reload"]);
   }
 
   private async getServerPort(port: number | undefined): Promise<number> {

--- a/src/commands/portal/serve.ts
+++ b/src/commands/portal/serve.ts
@@ -23,7 +23,7 @@ export default class PortalServe extends Command {
       description: "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     destination: Flags.string({
-      description: "[default: ./portal] path where the portal will be generated.",
+      description: "[default: <folder>/portal] path where the portal will be generated.",
     }),
     open: Flags.boolean({
       char: "o",

--- a/src/commands/portal/toc/new.ts
+++ b/src/commands/portal/toc/new.ts
@@ -23,21 +23,21 @@ https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-porta
     }),
     folder: Flags.string({
       description:
-        "[default: ./] path to the parent directory containing the build folder, which includes API specifications and configuration files."
+        "[default: ./] path to the parent directory containing the 'build' folder, which includes API specifications and configuration files."
     }),
     force: Flags.boolean({
       default: false,
-      description: "overwrite the toc.yml file if one already exists at the destination."
+      description: "overwrite the 'toc.yml' file if one already exists at the destination."
     }),
     "expand-endpoints": Flags.boolean({
       default: false,
       description:
-        "include individual entries for each endpoint in the generated toc.yml. Requires a valid API specification in the working directory."
+        "include individual entries for each endpoint in the generated 'toc.yml'. Requires a valid API specification in the working directory."
     }),
     "expand-models": Flags.boolean({
       default: false,
       description:
-        "include individual entries for each model in the generated toc.yml. Requires a valid API specification in the working directory."
+        "include individual entries for each model in the generated 'toc.yml'. Requires a valid API specification in the working directory."
     })
   };
 

--- a/src/commands/portal/toc/new.ts
+++ b/src/commands/portal/toc/new.ts
@@ -1,11 +1,13 @@
 import * as path from "path";
 import { Command, Flags } from "@oclif/core";
 import { PortalNewTocAction } from "../../../actions/portal/toc/new-toc.js";
+import { DirectoryPath } from "../../../types/file/directoryPath.js";
 
-const DEFAULT_FOLDER = process.cwd();
+const DEFAULT_WORKING_DIRECTORY = "./";
 
 export default class PortalTocNew extends Command {
-  static summary = 'Generates a TOC file based on the content directory and spec folder provided in your working directory';
+  static summary =
+    "Generates a TOC file based on the content directory and spec folder provided in your working directory";
 
   static description = `This command generates a new Table of Contents (TOC) file used in the
 generation of your API documentation portal.
@@ -17,25 +19,25 @@ https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-porta
 
   static flags = {
     destination: Flags.string({
-      parse: async (input: string) => path.resolve(input),
-      description: "optional path where the generated toc.yml file will be saved. Defaults to the current working directory if not provided.",
+      description: "[default: ./build/content] optional path where the generated toc.yml file will be saved."
     }),
     folder: Flags.string({
-      parse: async (input: string) => path.resolve(input),
-      description: "path to the working directory containing the API project files. Defaults to the current working directory if not specified.",
-      default: DEFAULT_FOLDER
+      description:
+        "[default: ./] path to the parent directory containing the build folder, which includes API specifications and configuration files."
     }),
     force: Flags.boolean({
       default: false,
-      description: "overwrite the toc.yml file if one already exists at the destination.",
+      description: "overwrite the toc.yml file if one already exists at the destination."
     }),
     "expand-endpoints": Flags.boolean({
       default: false,
-      description: "include individual entries for each endpoint in the generated toc.yml. Requires a valid API specification in the working directory."
+      description:
+        "include individual entries for each endpoint in the generated toc.yml. Requires a valid API specification in the working directory."
     }),
     "expand-models": Flags.boolean({
       default: false,
-      description: "include individual entries for each model in the generated toc.yml. Requires a valid API specification in the working directory."
+      description:
+        "include individual entries for each model in the generated toc.yml. Requires a valid API specification in the working directory."
     })
   };
 
@@ -58,10 +60,20 @@ A new toc file has been created at ./portal/content/toc.yml
   async run(): Promise<void> {
     const { flags } = await this.parse(PortalTocNew);
     const portalNewTocAction = new PortalNewTocAction();
+
+    const workingDirectory = new DirectoryPath(flags.folder ?? DEFAULT_WORKING_DIRECTORY);
+    const buildDirectory = flags.folder ? new DirectoryPath(flags.folder, "build") : workingDirectory.join("build");
+
+    let tocDirectory: DirectoryPath | undefined;
+
+    if (flags.destination) {
+      tocDirectory = new DirectoryPath(flags.destination);
+    }
+
     const result = await portalNewTocAction.createToc(
-      flags.folder,
+      buildDirectory,
       this.config.configDir,
-      flags.destination,
+      tocDirectory,
       flags.force,
       flags["expand-endpoints"],
       flags["expand-models"]

--- a/src/commands/portal/toc/new.ts
+++ b/src/commands/portal/toc/new.ts
@@ -1,4 +1,3 @@
-import * as path from "path";
 import { Command, Flags } from "@oclif/core";
 import { PortalNewTocAction } from "../../../actions/portal/toc/new-toc.js";
 import { DirectoryPath } from "../../../types/file/directoryPath.js";
@@ -42,15 +41,9 @@ https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-porta
   };
 
   static examples = [
-    `$ apimatic portal:toc:new --destination="./portal/content/"
-A new toc file has been created at ./portal/content/toc.yml
-`,
-    `$ apimatic portal:toc:new --folder="./my-project" 
-A new toc file has been created at ./my-project/content/toc.yml
-`,
-    `$ apimatic portal:toc:new --folder="./my-project" --destination="./portal/content/"
-A new toc file has been created at ./portal/content/toc.yml
-`
+    `$ apimatic portal:toc:new --destination="./portal/content/"`,
+    `$ apimatic portal:toc:new --folder="./my-project"`,
+    `$ apimatic portal:toc:new --folder="./my-project" --destination="./portal/content/"` 
   ];
 
   constructor(argv: string[], config: any) {

--- a/src/commands/portal/toc/new.ts
+++ b/src/commands/portal/toc/new.ts
@@ -18,7 +18,7 @@ https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-porta
 
   static flags = {
     destination: Flags.string({
-      description: "[default: ./build/content] optional path where the generated 'toc.yml' file will be saved."
+      description: "[default: <folder>/build/content] optional path where the generated 'toc.yml' file will be saved."
     }),
     folder: Flags.string({
       description:

--- a/src/commands/portal/toc/new.ts
+++ b/src/commands/portal/toc/new.ts
@@ -19,7 +19,7 @@ https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-porta
 
   static flags = {
     destination: Flags.string({
-      description: "[default: ./build/content] optional path where the generated toc.yml file will be saved."
+      description: "[default: ./build/content] optional path where the generated 'toc.yml' file will be saved."
     }),
     folder: Flags.string({
       description:

--- a/src/commands/sdk/generate.ts
+++ b/src/commands/sdk/generate.ts
@@ -48,16 +48,8 @@ Legacy: CS_NET_STANDARD_LIB|JAVA_ECLIPSE_JRE_LIB|PHP_GENERIC_LIB_V2|PYTHON_GENER
   };
 
   static examples = [
-    `$ apimatic sdk:generate --platform="CSHARP" --file="./specs/sample.json"
-Generating SDK... done
-Downloading SDK... done
-Success! Your SDK is located at swagger_sdk_csharp`,
-    `
-$ apimatic sdk:generate --platform="CSHARP" --url=https://petstore.swagger.io/v2/swagger.json
-Generating SDK... done
-Downloading SDK... done
-Success! Your SDK is located at swagger_sdk_csharp
-`
+    `$ apimatic sdk:generate --platform="CSHARP" --file="./specs/sample.json"`,
+    `$ apimatic sdk:generate --platform="CSHARP" --url=https://petstore.swagger.io/v2/swagger.json`
   ];
 
   async run() {

--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -37,7 +37,7 @@ export class PortalService {
     const file = new FileWrapper(buildFileStream);
 
     const authInfo: AuthInfo | null = await getAuthInfo(configDir.toString());
-    if (authInfo === null && !authKey) {
+    if (authInfo === null || authInfo.authKey === '' && !authKey) {
       return Result.failure("You are not logged in, please login using `auth:login` first.");
     }
 
@@ -146,34 +146,5 @@ export class PortalService {
       return await parseStreamBodyToJson(stream);
     }
     throw error;
-  };
-
-  private saveAndExtractErrorZipFile = async (error: ApiError, params: GeneratePortalParams): Promise<string> => {
-    const data = error.body as NodeJS.ReadableStream;
-    const writeStream = fs.createWriteStream(params.generatedPortalArtifactsZipFilePath);
-
-    //TODO: Extract zip to temp folder and only copy the the debug report.
-    return await new Promise<string>((resolve, reject) => {
-      data
-        .pipe(writeStream)
-        .on("finish", async () => {
-          await extractZipFile(params.generatedPortalArtifactsZipFilePath, params.generatedPortalArtifactsFolderPath);
-          await deleteFile(params.generatedPortalArtifactsZipFilePath);
-          await deleteFile(path.join(params.generatedPortalArtifactsFolderPath, "static"));
-          resolve(
-            getMessageInRedColor(
-              "An error occurred during portal generation due to an issue with the input. An error report has been written at the destination path: " +
-              path.join(params.generatedPortalArtifactsFolderPath, "apimatic-debug")
-            )
-          );
-        })
-        .on("error", async () => {
-          reject(
-            getMessageInRedColor(
-              "An error occurred during portal generation due to an issue with the input. The error report could not be generated. Please try again later."
-            )
-          );
-        });
-    });
   };
 }

--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -1,7 +1,5 @@
-import * as path from "path";
 import * as os from "os";
-import fsExtra from "fs-extra";
-import fs from "fs";
+import fs from "fs-extra";
 import {
   ContentType,
   DocsPortalManagementController,
@@ -17,9 +15,9 @@ import {
   InternalServerErrorResponseError
 } from "@apimatic/sdk";
 import { AuthInfo, getAuthInfo } from "../../client-utils/auth-manager.js";
-import { GeneratePortalParams, ErrorResponse } from "../../types/portal/generate.js";
+import { ErrorResponse } from "../../types/portal/generate.js";
 import { Result } from "../../types/common/result.js";
-import { getMessageInRedColor, parseStreamBodyToJson, extractZipFile, deleteFile } from "../../utils/utils.js";
+import { getMessageInRedColor, parseStreamBodyToJson } from "../../utils/utils.js";
 import { TransformationData } from "../../types/api/transform.js";
 import { Sdl } from "../../types/sdl/sdl.js";
 import { FilePath } from "../../types/file/filePath.js";
@@ -31,16 +29,14 @@ export class PortalService {
   private readonly TIMEOUT = 0;
   private readonly fileService = new FileService();
 
-
-  async generatePortal(buildPath: FilePath, configDir: DirectoryPath, authKey: string | null): Promise<Result<NodeJS.ReadableStream, string | NodeJS.ReadableStream>> {
+  async generatePortal(
+    buildPath: FilePath,
+    configDir: DirectoryPath,
+    authKey: string | null
+  ): Promise<Result<NodeJS.ReadableStream, string | NodeJS.ReadableStream>> {
     const buildFileStream = await this.fileService.getStream(buildPath);
     const file = new FileWrapper(buildFileStream);
-
     const authInfo: AuthInfo | null = await getAuthInfo(configDir.toString());
-    if (authInfo === null || authInfo.authKey === '' && !authKey) {
-      return Result.failure("You are not logged in, please login using `auth:login` first.");
-    }
-
     const authorizationHeader = this.createAuthorizationHeader(authInfo, authKey);
     const client = this.createApiClient(authorizationHeader);
     const docsPortalManagementController = new DocsPortalManagementController(client);
@@ -50,11 +46,13 @@ export class PortalService {
       return Result.success(response.result as NodeJS.ReadableStream);
     } catch (error) {
       return Result.failure(await this.handlePortalGenerationErrors(error));
+    } finally {
+      buildFileStream.close();
     }
   }
 
   public async generateSdl(specPath: string, configDir: string): Promise<Result<Sdl, string>> {
-    if (!(await fsExtra.pathExists(specPath))) {
+    if (!(await fs.pathExists(specPath))) {
       return Result.failure("Spec file doesn't exist");
     }
 

--- a/src/prompts/portal/generate.ts
+++ b/src/prompts/portal/generate.ts
@@ -1,5 +1,5 @@
 import { cancel, outro, select, spinner, isCancel } from "@clack/prompts";
-import { getMessageInRedColor } from "../../utils/utils.js";
+import { getMessageInCyanColor, getMessageInMagentaColor, getMessageInRedColor } from "../../utils/utils.js";
 import { DirectoryPath } from "../../types/file/directoryPath.js";
 
 export class PortalGeneratePrompts {
@@ -7,7 +7,7 @@ export class PortalGeneratePrompts {
 
   public async overwritePortal(directory: DirectoryPath): Promise<boolean> {
     const overwrite = await select({
-      message: `The destination '${directory}' is not empty, do you want to overwrite?`,
+      message: `⚠️ The destination '${directory}' is not empty, do you want to overwrite?`,
       options: [
         { value: true, label: "Yes" },
         { value: false, label: "No" }
@@ -72,11 +72,11 @@ export class PortalGeneratePrompts {
   }
 
   displayPortalGenerationMessage(): void {
-    this.spin.start("Generating portal...");
+    this.spin.start(getMessageInMagentaColor("Generating portal"));
   }
 
   displayPortalGenerationSuccessMessage(): void {
-    this.spin.stop("✅ Portal generated successfully.");
+    this.spin.stop(getMessageInCyanColor("✅  Portal generated successfully."));
   }
 
   displayPortalGenerationErrorMessage(): void {

--- a/src/prompts/portal/generate.ts
+++ b/src/prompts/portal/generate.ts
@@ -7,11 +7,12 @@ export class PortalGeneratePrompts {
 
   public async overwritePortal(directory: DirectoryPath): Promise<boolean> {
     const overwrite = await select({
-      message: `⚠️ The destination '${directory}' is not empty, do you want to overwrite?`,
+      message: `⚠️  The destination '${directory}' is not empty, do you want to overwrite?`,
       options: [
         { value: true, label: "Yes" },
         { value: false, label: "No" }
-      ], initialValue: false,
+      ],
+      initialValue: false
     });
 
     if (isCancel(overwrite)) {
@@ -29,34 +30,14 @@ export class PortalGeneratePrompts {
     // TODO: it should return false (no process exit);
   }
 
-  async overwriteExistingPortalArtifactsPrompt(): Promise<boolean> {
-    const useExistingFolder = await select({
-      message: `The destination folder is not empty, do you want to overwrite the existing files?`,
-      options: [
-        { value: "yes", label: "Yes" },
-        { value: "no", label: "No" }
-      ]
-    });
-
-    if (isCancel(useExistingFolder)) {
-      cancel("Operation cancelled.");
-      return process.exit(1);
-    }
-
-    if (useExistingFolder === "no") {
-      outro("Please enter a different destination folder or remove the existing files and try again.");
-    }
-
-    return useExistingFolder === "yes";
-  }
-
   async existingDestinationPortalZipPrompt(): Promise<boolean> {
     const useExistingZip = await select({
-      message: `A zip file already exists at the specified destination path, do you want to overwrite it?`,
+      message: `⚠️  A zip file already exists at the specified destination path, do you want to overwrite it?`,
       options: [
         { value: "yes", label: "Yes" },
         { value: "no", label: "No" }
-      ]
+      ],
+      initialValue: "no"
     });
 
     if (isCancel(useExistingZip)) {
@@ -77,10 +58,12 @@ export class PortalGeneratePrompts {
 
   displayPortalGenerationSuccessMessage(): void {
     this.spin.stop(getMessageInCyanColor("✅  Portal generated successfully."));
+    this.cleanUpStandardInput();
   }
 
   displayPortalGenerationErrorMessage(): void {
     this.spin.stop(getMessageInRedColor(`Portal Generation failed.`));
+    this.cleanUpStandardInput();
   }
 
   displayOutroMessage(generatedPortalPath: string): void {
@@ -89,5 +72,13 @@ export class PortalGeneratePrompts {
 
   logError(error: string): void {
     outro(error);
+  }
+
+  //This clears the standard input to allow interrupts like CTRL+C to work properly.
+  private cleanUpStandardInput(): void {
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
   }
 }

--- a/src/prompts/portal/quickstart.ts
+++ b/src/prompts/portal/quickstart.ts
@@ -11,9 +11,9 @@ import {
   isValidUrl,
   directoryToJson
 } from "../../utils/utils.js";
+import { BasePrompts } from "./common/base-prompts.js";
 
-export class PortalQuickstartPrompts {
-  private readonly spin = spinner();
+export class PortalQuickstartPrompts extends BasePrompts {
   private readonly vscodeExtensionUrl =
     "\u001b[4mhttps://marketplace.visualstudio.com/items?itemName=apimatic-developers.apimatic-for-vscode\u001b[0m";
   private readonly serverUrl = "\u001b[4mhttp://localhost:3000\u001b[0m";
@@ -273,7 +273,7 @@ export class PortalQuickstartPrompts {
       .map((line) => line.replace(/#.*/, (match) => getMessageInGreenColor(match)))
       .join("\n");
 
-    log.info(coloredLogString);
+    log.step(coloredLogString);
   }
 
   displayPortalGenerationMessage(): void {

--- a/src/prompts/portal/quickstart.ts
+++ b/src/prompts/portal/quickstart.ts
@@ -252,7 +252,7 @@ export class PortalQuickstartPrompts extends BasePrompts {
   }
 
   displayBuildDirectoryGenerationMessage(): void {
-    this.spin.start(getMessageInMagentaColor("Generating build directory... ⚙️"));
+    this.spin.start(getMessageInMagentaColor("Generating build directory ⚙️"));
   }
 
   displayBuildDirectoryGenerationErrorMessage(): void {

--- a/src/prompts/portal/quickstart.ts
+++ b/src/prompts/portal/quickstart.ts
@@ -90,12 +90,12 @@ export class PortalQuickstartPrompts extends BasePrompts {
     const quotes = ['"', "'"];
 
     for (const quote of quotes) {
-        if (str.startsWith(quote) && str.endsWith(quote) && str.length > 1) {
-            return str.slice(1, -1);
-        }
+      if (str.startsWith(quote) && str.endsWith(quote) && str.length > 1) {
+        return str.slice(1, -1);
+      }
     }
     return str;
-}
+  }
 
   async specPrompt(): Promise<string> {
     log.step(getMessageInOrangeColor(`Step 1 of 4: Import your OpenAPI Definition`));
@@ -103,7 +103,8 @@ export class PortalQuickstartPrompts extends BasePrompts {
     const spec = await text({
       message: `Provide a local path or a public URL for your OpenAPI definition file:`,
       placeholder: "Provide absolute URL/local path or press Enter to use sample OpenAPI file from APIMatic.",
-      defaultValue: "https://raw.githubusercontent.com/apimatic/static-portal-workflow/refs/heads/master/spec/Apimatic-Calculator.json",
+      defaultValue:
+        "https://raw.githubusercontent.com/apimatic/static-portal-workflow/refs/heads/master/spec/Apimatic-Calculator.json",
       validate: (input) => {
         if (!input) return;
 
@@ -276,19 +277,11 @@ export class PortalQuickstartPrompts extends BasePrompts {
     log.step(coloredLogString);
   }
 
-  displayPortalGenerationMessage(): void {
-    this.spin.start(getMessageInMagentaColor("Setting up portal"));
-  }
-
-  displayPortalGenerationSuccessMessage(): void {
-    this.spin.stop(getMessageInCyanColor("✅  Portal setup complete!"));
-  }
-
-  displayOutroMessage(directory: string): void {
+  displayOutroMessage(buildDirectory: string): void {
     log.step(
       getMessageInCyanColor(`📢  Your API Portal is live at: ${this.serverUrl}\n`) +
         getMessageInCyanColor(
-          `Hot reload enabled! Edit files in ${directory} to see changes instantly reflected in your API Portal.\n`
+          `Hot reload enabled! Edit files in ${buildDirectory} to see changes instantly reflected in your API Portal.\n`
         ) +
         getMessageInCyanColor(`Press CTRL+C to stop the server.`)
     );

--- a/src/prompts/portal/recipe/new-recipe.ts
+++ b/src/prompts/portal/recipe/new-recipe.ts
@@ -41,7 +41,7 @@ export class PortalRecipePrompts {
 
   public async buildConfigFilePathPrompt(buildDirectoryPath: string): Promise<string> {
     const buildConfigFilePath = await text({
-      message: `⚠️ APIMATIC-BUILD.json is required and was not found in "${buildDirectoryPath}".\nPlease enter the path to your build config file (relative to this directory):`,
+      message: `⚠️  APIMATIC-BUILD.json is required and was not found in "${buildDirectoryPath}".\nPlease enter the path to your build config file (relative to this directory):`,
       validate: (filePath) => {
         if (!filePath) {
           return "Build config file path cannot be empty. Please provide a valid file path.";
@@ -175,7 +175,8 @@ export class PortalRecipePrompts {
       options: [
         { value: "yes", label: "Yes" },
         { value: "no", label: "No" }
-      ]
+      ],
+      initialValue: "yes"
     });
 
     if (isCancel(addAnotherStep)) {

--- a/src/prompts/portal/serve.ts
+++ b/src/prompts/portal/serve.ts
@@ -24,7 +24,7 @@ export class PortalServePrompts extends BasePrompts {
     log.message(`The generated portal can be found at ${portalDirectory}`);
     if (!hotReloadDisabled)
     {
-      log.message(`🔍 Hot-Reload enabled. Watching the ${buildDirectory} folder for any changes.`);
+      log.message(`🔍 Hot reload enabled. Watching the ${buildDirectory} folder for any changes.`);
     }
     log.message(`Server started at http://localhost:${port}`);
     outro(`Press CTRL+C to stop the server.`);

--- a/src/prompts/portal/serve.ts
+++ b/src/prompts/portal/serve.ts
@@ -20,7 +20,12 @@ export class PortalServePrompts extends BasePrompts {
     return useExistingFolder === "yes";
   }
 
-  public displayOutroMessage(port: number): void {
+  public displayOutroMessage(buildDirectory: string, portalDirectory:string, port: number, hotReloadDisabled: boolean): void {
+    log.message(`The generated portal can be found at ${portalDirectory}`);
+    if (!hotReloadDisabled)
+    {
+      log.message(`🔍 Hot-Reload enabled. Watching the ${buildDirectory} folder for any changes.`);
+    }
     log.message(`Server started at http://localhost:${port}`);
     outro(`Press CTRL+C to stop the server.`);
   }

--- a/src/prompts/portal/serve.ts
+++ b/src/prompts/portal/serve.ts
@@ -5,11 +5,12 @@ import { BasePrompts } from "./common/base-prompts.js";
 export class PortalServePrompts extends BasePrompts {
   public async overwriteExistingPortalArtifactsPrompt(): Promise<boolean> {
     const useExistingFolder = await select({
-      message: `The destination folder is not empty, do you want to overwrite the existing files?`,
+      message: `⚠️  The destination folder is not empty, do you want to overwrite the existing files?`,
       options: [
         { value: "yes", label: "Yes" },
         { value: "no", label: "No" }
-      ]
+      ],
+      initialValue: "no"
     });
 
     if (isCancel(useExistingFolder)) {
@@ -20,13 +21,18 @@ export class PortalServePrompts extends BasePrompts {
     return useExistingFolder === "yes";
   }
 
-  public displayOutroMessage(buildDirectory: string, portalDirectory:string, port: number, hotReloadDisabled: boolean): void {
+  public displayOutroMessage(
+    buildDirectory: string,
+    portalDirectory: string,
+    port: number,
+    hotReloadDisabled: boolean
+  ): void {
     log.message(`The generated portal can be found at ${portalDirectory}`);
-    if (!hotReloadDisabled)
-    {
-      log.message(`🔍 Hot reload enabled. Watching the ${buildDirectory} folder for any changes.`);
-    }
     log.message(`Server started at http://localhost:${port}`);
+    if (!hotReloadDisabled) {
+      log.message(`🔍 Hot reload enabled. Watching the following build folder for any changes:`);
+      log.message(`${buildDirectory}`);
+    }
     outro(`Press CTRL+C to stop the server.`);
   }
 }

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -5,11 +5,12 @@ export class PortalNewTocPrompts {
 
   async overwriteExistingTocPrompt(): Promise<boolean> {
     const useExistingFile = await select({
-      message: `A toc.yml file already exists at the specified destination path, do you want to overwrite it?`,
+      message: `⚠️  A toc.yml file already exists at the specified destination path, do you want to overwrite it?`,
       options: [
         { value: "yes", label: "Yes" },
         { value: "no", label: "No" }
-      ]
+      ],
+      initialValue: "no"
     });
 
     if (isCancel(useExistingFile)) {
@@ -28,7 +29,7 @@ export class PortalNewTocPrompts {
     this.spin.start(message);
   }
 
-  stopProgressIndicatorWithMessage(message: string) : void {
+  stopProgressIndicatorWithMessage(message: string): void {
     this.spin.stop(message);
   }
 
@@ -47,4 +48,4 @@ export class PortalNewTocPrompts {
   displayInfo(message: string): void {
     log.step(message);
   }
-} 
+}


### PR DESCRIPTION
Covers the following changes:

- Adds the build directory structure to the recipe and toc commands.
- Improves messaging across the portal commands.
- Removed `--build-config` flag from `portal:recipe:new` command.
- Minor bug fixes in portal generate, serve and quickstart commands