### PR TITLE
fix: avoid adding empty events or models section in toc

### DIFF
--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -75,10 +75,6 @@ export class PortalNewTocAction {
         callbackGroups: new Map()
       };
 
-      if (!expandEndpoints && !expandModels && !expandWebhooks && !expandCallbacks) {
-        return defaultComponents;
-      }
-
       const specDirectory = buildDirectory.join('spec');
 
       if (!(await this.fileService.directoryExists(specDirectory))) {
@@ -103,12 +99,12 @@ export class PortalNewTocAction {
           return defaultComponents;
         }
 
-        const endpointGroups = expandEndpoints ? extractEndpointGroupsForToc(result.value) : new Map();
-        const models = expandModels ? extractModelsForToc(result.value) : [];
-        const webhookGroups = expandWebhooks ? extractWebhooksForToc(result.value) : new Map();
-        const callbackGroups = expandCallbacks ? extractCallbacksForToc(result.value) : new Map();
-
-        return { endpointGroups, models, webhookGroups, callbackGroups };
+        return {
+          endpointGroups: extractEndpointGroupsForToc(result.value),
+          models: extractModelsForToc(result.value),
+          webhookGroups: extractWebhooksForToc(result.value),
+          callbackGroups: extractCallbacksForToc(result.value)
+        };
       });
     })();
     const contentContext = new ContentContext(contentDirectory);
@@ -123,10 +119,10 @@ export class PortalNewTocAction {
     }
 
     const toc = this.tocGenerator.createTocStructure(
-      sdlTocComponents.endpointGroups,
-      sdlTocComponents.models,
-      sdlTocComponents.webhookGroups,
-      sdlTocComponents.callbackGroups,
+      { data: sdlTocComponents.endpointGroups, expand: expandEndpoints },
+      { data: sdlTocComponents.models, expand: expandModels },
+      { data: sdlTocComponents.webhookGroups, expand: expandWebhooks },
+      { data: sdlTocComponents.callbackGroups, expand: expandCallbacks },
       contentGroups
     );
     const yamlString = this.tocGenerator.transformToYaml(toc);

--- a/src/application/portal/toc/toc-structure-generator.ts
+++ b/src/application/portal/toc/toc-structure-generator.ts
@@ -128,7 +128,7 @@ export class TocStructureGenerator {
     }
     return [
       {
-        generate: null,
+        generate: "Callbacks",
         from: 'callbacks'
       }
     ];
@@ -159,7 +159,7 @@ export class TocStructureGenerator {
     }
     return [
       {
-        generate: null,
+        generate: "Webhooks",
         from: 'webhooks'
       }
     ];

--- a/src/application/portal/toc/toc-structure-generator.ts
+++ b/src/application/portal/toc/toc-structure-generator.ts
@@ -12,14 +12,36 @@ import {
 
 // TODO: Refactor
 
+type Endpoints = {
+  data: Map<string, TocEndpoint[]>;
+  expand: boolean;
+};
+
+type Webhooks = {
+  data: Map<string, TocWebhookPage[]>;
+  expand: boolean;
+};
+
+type Callbacks = {
+  data: Map<string, TocCallbackPage[]>;
+  expand: boolean;
+};
+
+type Models = {
+  data: TocModelPage[];
+  expand: boolean;
+};
+
 export class TocStructureGenerator {
   createTocStructure(
-    endpointGroups: Map<string, TocEndpoint[]>,
-    models: TocModelPage[],
-    webhookGroups: Map<string, TocWebhookPage[]>,
-    callbackGroups: Map<string, TocCallbackPage[]>,
+    endpoints: Endpoints,
+    models: Models,
+    webhooks: Webhooks,
+    callbacks: Callbacks,
     contentGroups: TocGroup[] = []
   ): Toc {
+    const events = [...this.getCallbacksSection(callbacks), ...this.getWebhooksSection(webhooks)];
+
     return {
       toc: [
         {
@@ -32,11 +54,16 @@ export class TocStructureGenerator {
           ]
         },
         ...contentGroups,
-        this.getEndpointsSection(endpointGroups),
-        {
-          group: 'Events',
-          items: [this.getCallbacksSection(callbackGroups), this.getWebhooksSection(webhookGroups)]
-        },
+        this.getEndpointsSection(endpoints),
+        // only add if events exist
+        ...(events.length > 0
+          ? [
+              {
+                group: 'Events',
+                items: events
+              }
+            ]
+          : []),
         this.getModelsSection(models),
         {
           generate: 'SDK Infrastructure',
@@ -54,8 +81,8 @@ export class TocStructureGenerator {
     });
   }
 
-  private getEndpointsSection(endpointGroups: Map<string, TocEndpoint[]>): TocGroup | TocGenerated {
-    if (endpointGroups.size === 0) {
+  private getEndpointsSection(endpoints: Endpoints): TocGroup | TocGenerated {
+    if (!endpoints.expand || endpoints.data.size === 0) {
       return {
         generate: 'API Endpoints',
         from: 'endpoints'
@@ -63,7 +90,7 @@ export class TocStructureGenerator {
     }
     return {
       group: 'API Endpoints',
-      items: Array.from(endpointGroups).map(([groupName, endpoints]) => ({
+      items: Array.from(endpoints.data).map(([groupName, endpoints]) => ({
         group: groupName,
         items: [
           {
@@ -77,52 +104,70 @@ export class TocStructureGenerator {
     };
   }
 
-  private getCallbacksSection(callbackGroups: Map<string, TocCallbackPage[]>): TocGroup | TocGenerated {
-    if (callbackGroups.size === 0) {
-      return {
+  private getCallbacksSection(callbacks: Callbacks): (TocGroup | TocGenerated)[] {
+    if (callbacks.data.size === 0) {
+      return [];
+    }
+    if (callbacks.expand === true) {
+      if (callbacks.data.size === 1) {
+        return [
+          {
+            group: Array.from(callbacks.data.keys())[0],
+            items: Array.from(callbacks.data.values())[0]
+          }
+        ];
+      }
+      return [
+        {
+          group: 'Callbacks',
+          items: Array.from(callbacks.data).map(([groupName, eventList]) => ({
+            group: groupName,
+            items: eventList
+          }))
+        }
+      ];
+    }
+    return [
+      {
         generate: null,
         from: 'callbacks'
-      };
-    }
-    if (callbackGroups.size === 1) {
-      return {
-        group: Array.from(callbackGroups.keys())[0],
-        items: Array.from(callbackGroups.values())[0]
-      };
-    }
-    return {
-      group: 'Callbacks',
-      items: Array.from(callbackGroups).map(([groupName, eventList]) => ({
-        group: groupName,
-        items: eventList
-      }))
-    };
+      }
+    ];
   }
 
-  private getWebhooksSection(webhookGroups: Map<string, TocWebhookPage[]>): TocGroup | TocGenerated {
-    if (webhookGroups.size === 0) {
-      return {
+  private getWebhooksSection(webhooks: Webhooks): (TocGroup | TocGenerated)[] {
+    if (webhooks.data.size === 0) {
+      return [];
+    }
+    if (webhooks.expand === true) {
+      if (webhooks.data.size === 1) {
+        return [
+          {
+            group: Array.from(webhooks.data.keys())[0],
+            items: Array.from(webhooks.data.values())[0]
+          }
+        ];
+      }
+      return [
+        {
+          group: 'Webhooks',
+          items: Array.from(webhooks.data).map(([groupName, eventList]) => ({
+            group: groupName,
+            items: eventList
+          }))
+        }
+      ];
+    }
+    return [
+      {
         generate: null,
         from: 'webhooks'
-      };
-    }
-    if (webhookGroups.size === 1) {
-      return {
-        group: Array.from(webhookGroups.keys())[0],
-        items: Array.from(webhookGroups.values())[0]
-      };
-    }
-    return {
-      group: 'Webhooks',
-      items: Array.from(webhookGroups).map(([groupName, eventList]) => ({
-        group: groupName,
-        items: eventList
-      }))
-    };
+      }
+    ];
   }
 
-  private getModelsSection(models: TocModelPage[]): TocGroup | TocGenerated {
-    if (models.length === 0) {
+  private getModelsSection(models: Models): TocGroup | TocGenerated {
+    if (!models.expand || models.data.length === 0) {
       return {
         generate: 'Models',
         from: 'models'
@@ -130,7 +175,7 @@ export class TocStructureGenerator {
     }
     return {
       group: 'Models',
-      items: models
+      items: models.data
     };
   }
 

--- a/src/application/portal/toc/toc-structure-generator.ts
+++ b/src/application/portal/toc/toc-structure-generator.ts
@@ -128,7 +128,7 @@ export class TocStructureGenerator {
     }
     return [
       {
-        generate: "Callbacks",
+        generate: 'Callbacks',
         from: 'callbacks'
       }
     ];
@@ -159,7 +159,7 @@ export class TocStructureGenerator {
     }
     return [
       {
-        generate: "Webhooks",
+        generate: 'Webhooks',
         from: 'webhooks'
       }
     ];

--- a/src/application/portal/toc/toc-structure-generator.ts
+++ b/src/application/portal/toc/toc-structure-generator.ts
@@ -55,7 +55,6 @@ export class TocStructureGenerator {
         },
         ...contentGroups,
         this.getEndpointsSection(endpoints),
-        // only add if events exist
         ...(events.length > 0
           ? [
               {
@@ -64,7 +63,7 @@ export class TocStructureGenerator {
               }
             ]
           : []),
-        this.getModelsSection(models),
+        ...this.getModelsSection(models),
         {
           generate: 'SDK Infrastructure',
           from: 'sdk-infra'
@@ -166,17 +165,24 @@ export class TocStructureGenerator {
     ];
   }
 
-  private getModelsSection(models: Models): TocGroup | TocGenerated {
-    if (!models.expand || models.data.length === 0) {
-      return {
-        generate: 'Models',
-        from: 'models'
-      };
+  private getModelsSection(models: Models): (TocGroup | TocGenerated)[] {
+    if (models.data.length === 0) {
+      return [];
     }
-    return {
-      group: 'Models',
-      items: models.data
-    };
+    if (!models.expand) {
+      return [
+        {
+          generate: 'Models',
+          from: 'models'
+        }
+      ];
+    }
+    return [
+      {
+        group: 'Models',
+        items: models.data
+      }
+    ];
   }
 
   private transformKeys(obj: any): any {


### PR DESCRIPTION
This PR fixes an issue where the TOC was adding Events and Models sections even when they were not present in the spec file. Now, these sections are generated only if the spec file contains the relevant data.