### PR TITLE
feat: add support for csharp v2 sdk generation

### DIFF
--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -236,6 +236,7 @@ export class PortalService {
     [Language.PYTHON]: Platforms.PythonGenericLib,
     [Language.RUBY]: Platforms.RubyGenericLib,
     [Language.TYPESCRIPT]: Platforms.TsGenericLib,
-    [Language.GO]: Platforms.GoGenericLib
+    [Language.GO]: Platforms.GoGenericLib,
+    [Language.CSHARP_V2]: Platforms.CsNetStandardLibV2
   };
 }

--- a/src/prompts/sdk/quickstart.ts
+++ b/src/prompts/sdk/quickstart.ts
@@ -153,7 +153,8 @@ export class SdkQuickstartPrompts {
         { label: "Java", value: Language.JAVA },
         { label: "C#", value: Language.CSHARP },
         { label: "PHP", value: Language.PHP },
-        { label: "Go", value: Language.GO }
+        { label: "Go", value: Language.GO },
+        { label: "C# V2 (alpha)", value: Language.CSHARP_V2, hint: "New ✨" }
       ]
     });
 

--- a/src/types/sdk/generate.ts
+++ b/src/types/sdk/generate.ts
@@ -5,7 +5,8 @@ export enum Language {
   PYTHON = "python",
   RUBY = "ruby",
   TYPESCRIPT = "typescript",
-  GO = "go"
+  GO = "go",
+  CSHARP_V2 = "csharp_v2",
 }
 
 const languageMap: { [key: number]: Language } = {
@@ -16,6 +17,7 @@ const languageMap: { [key: number]: Language } = {
   16: Language.PYTHON,
   32: Language.RUBY,
   128: Language.TYPESCRIPT,
+  256: Language.CSHARP_V2,
 };
 
 export function mapLanguages(languageFlag: number): Language[] {


### PR DESCRIPTION
What was added?

- Added a new SDK language i.e. `csharp_v2`.
- Updated `apimatic quickstart` and `apimatic sdk generate` commands to incorporate generation of new SDK.