### PR TITLE
feat: add api-version flag in sdk generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install -g @apimatic/cli
 $ apimatic COMMAND
 running command...
 $ apimatic (--version)
-@apimatic/cli/1.1.0-beta.7 win32-x64 node-v23.4.0
+@apimatic/cli/1.1.0-beta.8 win32-x64 node-v23.4.0
 $ apimatic --help [COMMAND]
 USAGE
   $ apimatic COMMAND
@@ -411,8 +411,8 @@ Generate an SDK for your API
 
 ```
 USAGE
-  $ apimatic sdk generate -l csharp|java|php|python|ruby|typescript|go [-i <value>] [-d <value>] [-f] [--zip] [-k
-    <value>]
+  $ apimatic sdk generate -l csharp|java|php|python|ruby|typescript|go [-i <value>] [-d <value>] [--api-version
+    <value>] [-f] [--zip] [-k <value>]
 
 FLAGS
   -d, --destination=<value>  directory where the SDK will be generated
@@ -422,7 +422,8 @@ FLAGS
   -k, --auth-key=<value>     override current authentication state with an authentication key.
   -l, --language=<option>    (required) programming language for SDK generation
                              <options: csharp|java|php|python|ruby|typescript|go>
-      --zip                  download the generated SDK as a .zip archive
+      --api-version=<value>  Version of the API to use for SDK generation (if multiple versions exist)
+      --zip                  Download the generated SDK as a .zip archive
 
 DESCRIPTION
   Generate an SDK for your API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@apimatic/cli",
-    "version": "1.1.0-beta.7",
+    "version": "1.1.0-beta.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@apimatic/cli",
-            "version": "1.1.0-beta.7",
+            "version": "1.1.0-beta.8",
             "license": "MIT",
             "dependencies": {
                 "@apimatic/sdk": "^0.2.0-alpha.7",

--- a/src/actions/sdk/generate.ts
+++ b/src/actions/sdk/generate.ts
@@ -37,26 +37,30 @@ export class GenerateAction {
     }
 
     const versionedBuildContext = new VersionedBuildContext(buildDirectory);
-    if (await versionedBuildContext.isVersioned()) {
-      const versionDirs = await versionedBuildContext.getVersionDirectories();
-      if (versionDirs.length === 0) {
-        this.prompts.versionedBuildEmpty(await versionedBuildContext.getVersionsDirectory());
+    const versionedBuildResult = await versionedBuildContext.validate();
+    if (versionedBuildResult.isValid) {
+      if (versionedBuildResult.versions.length === 0) {
+        this.prompts.versionedBuildEmpty(versionedBuildResult.versionsDirectory);
         return ActionResult.failed();
       }
 
-      const resolvedDirectory = versionDirs.length === 1
-        ? versionDirs[0]
-        : apiVersion
-          ? await versionedBuildContext.resolveVersionDirectory(apiVersion)
-          : await this.prompts.selectVersion(versionDirs);
+      if (apiVersion && !versionedBuildResult.versions.includes(apiVersion)) {
+        this.prompts.versionNotFound();
+          return ActionResult.failed();
+        }
 
-      if (!resolvedDirectory) {
-        if (apiVersion) this.prompts.versionNotFound();
-        return apiVersion ? ActionResult.failed() : ActionResult.cancelled();
+      const version = versionedBuildResult.versions.length === 1
+        ? versionedBuildResult.versions[0]
+        : apiVersion
+          ? apiVersion
+          : await this.prompts.selectVersion(versionedBuildResult.versions);
+
+      if (!version) {
+        return ActionResult.cancelled();
       }
 
-      buildDirectory = resolvedDirectory;
-      sdkDirectory = sdkDirectory.join(resolvedDirectory.leafName());
+      buildDirectory = versionedBuildResult.versionsDirectory.join(version);
+      sdkDirectory = sdkDirectory.join(version);
     }
 
     const specDirectory = buildDirectory.join("spec");

--- a/src/actions/sdk/generate.ts
+++ b/src/actions/sdk/generate.ts
@@ -28,7 +28,8 @@ export class GenerateAction {
     sdkDirectory: DirectoryPath,
     language: Language,
     force: boolean,
-    zipSdk: boolean
+    zipSdk: boolean,
+    apiVersion?: string
   ): Promise<ActionResult> => {
     if (buildDirectory.isEqual(sdkDirectory)) {
       this.prompts.sameBuildAndSdkDir(buildDirectory);
@@ -36,14 +37,26 @@ export class GenerateAction {
     }
 
     const versionedBuildContext = new VersionedBuildContext(buildDirectory);
-    if (await versionedBuildContext.exists()) {
-      const resolvedDirectory = await versionedBuildContext.getResolvedBuildDirectory();
-      if (!resolvedDirectory) {
-        this.prompts.versionedBuildEmpty();
+    if (await versionedBuildContext.isVersioned()) {
+      const versionDirs = await versionedBuildContext.getVersionDirectories();
+      if (versionDirs.length === 0) {
+        this.prompts.versionedBuildEmpty(await versionedBuildContext.getVersionsDirectory());
         return ActionResult.failed();
       }
+
+      const resolvedDirectory = versionDirs.length === 1
+        ? versionDirs[0]
+        : apiVersion
+          ? await versionedBuildContext.resolveVersionDirectory(apiVersion)
+          : await this.prompts.selectVersion(versionDirs);
+
+      if (!resolvedDirectory) {
+        if (apiVersion) this.prompts.versionNotFound();
+        return apiVersion ? ActionResult.failed() : ActionResult.cancelled();
+      }
+
       buildDirectory = resolvedDirectory;
-      this.prompts.versionedBuild(versionedBuildContext.getRelativePath(resolvedDirectory));
+      sdkDirectory = sdkDirectory.join(resolvedDirectory.leafName());
     }
 
     const specDirectory = buildDirectory.join("spec");

--- a/src/actions/sdk/generate.ts
+++ b/src/actions/sdk/generate.ts
@@ -44,19 +44,21 @@ export class GenerateAction {
         return ActionResult.failed();
       }
 
-      if (apiVersion && !versionedBuildResult.versions.includes(apiVersion)) {
-        this.prompts.versionNotFound();
+      let version: string;
+      if (apiVersion) {
+        if (!versionedBuildResult.versions.includes(apiVersion)) {
+          this.prompts.versionNotFound();
           return ActionResult.failed();
         }
-
-      const version = versionedBuildResult.versions.length === 1
-        ? versionedBuildResult.versions[0]
-        : apiVersion
-          ? apiVersion
-          : await this.prompts.selectVersion(versionedBuildResult.versions);
-
-      if (!version) {
-        return ActionResult.cancelled();
+        version = apiVersion;
+      } else if (versionedBuildResult.versions.length === 1) {
+        version = versionedBuildResult.versions[0];
+      } else {
+        const selectedVersion = await this.prompts.selectVersion(versionedBuildResult.versions);
+        if (!selectedVersion) {
+          return ActionResult.cancelled();
+        }
+        version = selectedVersion;
       }
 
       buildDirectory = versionedBuildResult.versionsDirectory.join(version);

--- a/src/commands/sdk/generate.ts
+++ b/src/commands/sdk/generate.ts
@@ -26,6 +26,9 @@ Supports multiple programming languages including Java, C#, Python, JavaScript, 
       char: "d",
       description: "Directory where the SDK will be generated"
     }),
+    "api-version": Flags.string({
+      description: "Version of the API documentation to use for SDK generation (if multiple versions exist)"
+    }),
     ...FlagsProvider.force,
     zip: Flags.boolean({
       default: false,
@@ -44,7 +47,7 @@ Supports multiple programming languages including Java, C#, Python, JavaScript, 
 
   async run() {
     const {
-      flags: { language, input, destination, force, zip: zipSdk, "auth-key": authKey }
+      flags: { language, input, destination, force, zip: zipSdk, "auth-key": authKey, "api-version": apiVersion }
     } = await this.parse(SdkGenerate);
 
     const workingDirectory = DirectoryPath.createInput(input);
@@ -58,7 +61,7 @@ Supports multiple programming languages including Java, C#, Python, JavaScript, 
 
     intro("Generate SDK");
     const action = new GenerateAction(this.getConfigDir(), commandMetadata, authKey);
-    const result = await action.execute(buildDirectory, sdkDirectory, language as Language, force, zipSdk);
+    const result = await action.execute(buildDirectory, sdkDirectory, language as Language, force, zipSdk, apiVersion);
     outro(result);
   }
 

--- a/src/commands/sdk/generate.ts
+++ b/src/commands/sdk/generate.ts
@@ -27,7 +27,7 @@ Supports multiple programming languages including Java, C#, Python, JavaScript, 
       description: "Directory where the SDK will be generated"
     }),
     "api-version": Flags.string({
-      description: "Version of the API documentation to use for SDK generation (if multiple versions exist)"
+      description: "Version of the API to use for SDK generation (if multiple versions exist)"
     }),
     ...FlagsProvider.force,
     zip: Flags.boolean({

--- a/src/prompts/sdk/generate.ts
+++ b/src/prompts/sdk/generate.ts
@@ -1,4 +1,4 @@
-import { isCancel, confirm, log } from "@clack/prompts";
+import { isCancel, confirm, log, select } from "@clack/prompts";
 import { DirectoryPath } from "../../types/file/directoryPath.js";
 import { format as f, } from "../format.js";
 import { Result } from "neverthrow";
@@ -47,13 +47,26 @@ export class SdkGeneratePrompts {
     log.error(serviceError.errorMessage);
   }
 
-  public versionedBuildEmpty() {
-    const message = `The ${f.var("versioned_docs")} directory is empty or contains no valid versions.`;
+  public versionedBuildEmpty(directory: DirectoryPath) {
+    const message = `The ${f.var(directory.leafName())} directory is either empty or invalid: ${f.path(directory)}`;
     this.logGenerationError(message);
   }
 
-  public versionedBuild(relativePath: string) {
-    log.warning(`SDK Generation for multi-versioned builds is not supported. Generating SDK for ${f.var(relativePath)} instead.`);
+  public versionNotFound() {
+    this.logGenerationError(`The API version is invalid.`);
+  }
+
+  public async selectVersion(versions: DirectoryPath[]): Promise<DirectoryPath | undefined> {
+    const version = await select({
+      message: "Select an API version for SDK generation:",
+      options: versions.map((v) => ({ label: v.leafName(), value: v }))
+    });
+
+    if (isCancel(version)) {
+      return undefined;
+    }
+
+    return version;
   }
 
   public sdkGenerated(sdk: DirectoryPath) {

--- a/src/prompts/sdk/generate.ts
+++ b/src/prompts/sdk/generate.ts
@@ -56,10 +56,10 @@ export class SdkGeneratePrompts {
     this.logGenerationError(`The API version is invalid.`);
   }
 
-  public async selectVersion(versions: DirectoryPath[]): Promise<DirectoryPath | undefined> {
+  public async selectVersion(versions: string[]): Promise<string | undefined> {
     const version = await select({
       message: "Select an API version for SDK generation:",
-      options: versions.map((v) => ({ label: v.leafName(), value: v }))
+      options: versions.map((v) => ({ label: v, value: v }))
     });
 
     if (isCancel(version)) {

--- a/src/types/versioned-build-context.ts
+++ b/src/types/versioned-build-context.ts
@@ -3,6 +3,7 @@ import { DirectoryPath } from "./file/directoryPath.js";
 import { BuildContext } from "./build-context.js";
 import { BuildConfig } from "./build/build.js";
 
+// TODO: remove BuildContext from this class
 export class VersionedBuildContext {
   private readonly fileService = new FileService();
   private readonly buildContext: BuildContext;

--- a/src/types/versioned-build-context.ts
+++ b/src/types/versioned-build-context.ts
@@ -1,27 +1,52 @@
-import * as path from "path";
 import { FileService } from "../infrastructure/file-service.js";
 import { DirectoryPath } from "./file/directoryPath.js";
+import { FilePath } from "./file/filePath.js";
+import { FileName } from "./file/fileName.js";
 
 export class VersionedBuildContext {
   private readonly fileService = new FileService();
-  private readonly versionedDocsDir: DirectoryPath;
+  private readonly buildDirectory: DirectoryPath;
+  private buildConfig: Record<string, unknown> | undefined;
 
   constructor(buildDirectory: DirectoryPath) {
-    this.versionedDocsDir = buildDirectory.join("versioned_docs");
+    this.buildDirectory = buildDirectory;
   }
 
-  public async exists(): Promise<boolean> {
-    return this.fileService.directoryExists(this.versionedDocsDir);
+  private async getBuildConfig(): Promise<Record<string, unknown> | undefined> {
+    if (this.buildConfig !== undefined) {
+      return this.buildConfig;
+    }
+    const buildJsonPath = new FilePath(this.buildDirectory, new FileName("APIMATIC-BUILD.json"));
+    if (!(await this.fileService.fileExists(buildJsonPath))) {
+      return undefined;
+    }
+    const contents = await this.fileService.getContents(buildJsonPath);
+    this.buildConfig = JSON.parse(contents);
+    return this.buildConfig;
   }
 
-  public async getResolvedBuildDirectory(): Promise<DirectoryPath | null> {
-    const subDirs = await this.fileService.getSubDirectoriesPaths(this.versionedDocsDir);
-    if (subDirs.length === 0) 
-      return null;
-    return subDirs[0];
+  public async isVersioned(): Promise<boolean> {
+    const config = await this.getBuildConfig();
+    return config !== undefined && "generateVersionedPortal" in config;
   }
 
-  public getRelativePath(resolvedDirectory: DirectoryPath): string {
-    return path.join(".", "src", "versioned_docs", resolvedDirectory.leafName());
+  public async getVersionsDirectory(): Promise<DirectoryPath> {
+    const config = await this.getBuildConfig();
+    const versionsPath = (config?.versionsPath as string) ?? "versioned_docs";
+    return this.buildDirectory.join(versionsPath);
+  }
+
+  public async getVersionDirectories(): Promise<DirectoryPath[]> {
+    const versionsDir = await this.getVersionsDirectory();
+    if (!(await this.fileService.directoryExists(versionsDir))) {
+      return [];
+    }
+    const subDirs = await this.fileService.getSubDirectoriesPaths(versionsDir);
+    return subDirs.filter((d) => d.leafName().startsWith("version-"));
+  }
+
+  public async resolveVersionDirectory(apiVersion: string): Promise<DirectoryPath | null> {
+    const versionDirs = await this.getVersionDirectories();
+    return versionDirs.find((dir) => dir.leafName() === apiVersion) ?? null;
   }
 }

--- a/src/types/versioned-build-context.ts
+++ b/src/types/versioned-build-context.ts
@@ -8,32 +8,30 @@ type VersionedBuildValidateResult = { isValid: false; } | {
   versions: string[];
 };
 
-// TODO: remove BuildContext from this class
 export class VersionedBuildContext {
   private readonly fileService = new FileService();
-  private readonly buildContext: BuildContext;
   private readonly buildDirectory: DirectoryPath;
 
   constructor(buildDirectory: DirectoryPath) {
     this.buildDirectory = buildDirectory;
-    this.buildContext = new BuildContext(buildDirectory);
   }
 
   public async validate(): Promise<VersionedBuildValidateResult> {
-    if (!(await this.buildContext.validate())) {
+    const buildContext = new BuildContext(this.buildDirectory);
+    if (!(await buildContext.validate())) {
       return { isValid: false };
     }
-    const config = await this.buildContext.getBuildFileContents();
-    if (!config || !("generateVersionedPortal" in config)) {
+    const config = await buildContext.getBuildFileContents();
+    if (!("generateVersionedPortal" in config)) {
       return { isValid: false };
     }
-    const versionsPath = (config?.versionsPath as string) ?? "versioned_docs";
-    const versionsDir = this.buildDirectory.join(versionsPath);
-    if (!(await this.fileService.directoryExists(versionsDir))) {
+    const versionsPath = (config.versionsPath as string) ?? "versioned_docs";
+    const versionsDirectory = this.buildDirectory.join(versionsPath);
+    if (!(await this.fileService.directoryExists(versionsDirectory))) {
       return { isValid: false };
     }
-    const versionsDirs = await this.fileService.getSubDirectoriesPaths(versionsDir);
+    const versionsDirs = await this.fileService.getSubDirectoriesPaths(versionsDirectory);
     const versions = versionsDirs.map((dir) => dir.leafName());
-    return { isValid: true, versionsDirectory: versionsDir, versions: versions };
+    return { isValid: true, versionsDirectory, versions };
   }
 }

--- a/src/types/versioned-build-context.ts
+++ b/src/types/versioned-build-context.ts
@@ -1,27 +1,27 @@
 import { FileService } from "../infrastructure/file-service.js";
 import { DirectoryPath } from "./file/directoryPath.js";
-import { FilePath } from "./file/filePath.js";
-import { FileName } from "./file/fileName.js";
+import { BuildContext } from "./build-context.js";
+import { BuildConfig } from "./build/build.js";
 
 export class VersionedBuildContext {
   private readonly fileService = new FileService();
+  private readonly buildContext: BuildContext;
   private readonly buildDirectory: DirectoryPath;
-  private buildConfig: Record<string, unknown> | undefined;
+  private buildConfig: BuildConfig | undefined;
 
   constructor(buildDirectory: DirectoryPath) {
     this.buildDirectory = buildDirectory;
+    this.buildContext = new BuildContext(buildDirectory);
   }
 
-  private async getBuildConfig(): Promise<Record<string, unknown> | undefined> {
+  private async getBuildConfig(): Promise<BuildConfig | undefined> {
     if (this.buildConfig !== undefined) {
       return this.buildConfig;
     }
-    const buildJsonPath = new FilePath(this.buildDirectory, new FileName("APIMATIC-BUILD.json"));
-    if (!(await this.fileService.fileExists(buildJsonPath))) {
+    if (!(await this.buildContext.validate())) {
       return undefined;
     }
-    const contents = await this.fileService.getContents(buildJsonPath);
-    this.buildConfig = JSON.parse(contents);
+    this.buildConfig = await this.buildContext.getBuildFileContents();
     return this.buildConfig;
   }
 
@@ -41,8 +41,7 @@ export class VersionedBuildContext {
     if (!(await this.fileService.directoryExists(versionsDir))) {
       return [];
     }
-    const subDirs = await this.fileService.getSubDirectoriesPaths(versionsDir);
-    return subDirs.filter((d) => d.leafName().startsWith("version-"));
+    return await this.fileService.getSubDirectoriesPaths(versionsDir);
   }
 
   public async resolveVersionDirectory(apiVersion: string): Promise<DirectoryPath | null> {

--- a/src/types/versioned-build-context.ts
+++ b/src/types/versioned-build-context.ts
@@ -1,52 +1,39 @@
 import { FileService } from "../infrastructure/file-service.js";
 import { DirectoryPath } from "./file/directoryPath.js";
 import { BuildContext } from "./build-context.js";
-import { BuildConfig } from "./build/build.js";
+
+type VersionedBuildValidateResult = { isValid: false; } | {
+  isValid: true;
+  versionsDirectory: DirectoryPath;
+  versions: string[];
+};
 
 // TODO: remove BuildContext from this class
 export class VersionedBuildContext {
   private readonly fileService = new FileService();
   private readonly buildContext: BuildContext;
   private readonly buildDirectory: DirectoryPath;
-  private buildConfig: BuildConfig | undefined;
 
   constructor(buildDirectory: DirectoryPath) {
     this.buildDirectory = buildDirectory;
     this.buildContext = new BuildContext(buildDirectory);
   }
 
-  private async getBuildConfig(): Promise<BuildConfig | undefined> {
-    if (this.buildConfig !== undefined) {
-      return this.buildConfig;
-    }
+  public async validate(): Promise<VersionedBuildValidateResult> {
     if (!(await this.buildContext.validate())) {
-      return undefined;
+      return { isValid: false };
     }
-    this.buildConfig = await this.buildContext.getBuildFileContents();
-    return this.buildConfig;
-  }
-
-  public async isVersioned(): Promise<boolean> {
-    const config = await this.getBuildConfig();
-    return config !== undefined && "generateVersionedPortal" in config;
-  }
-
-  public async getVersionsDirectory(): Promise<DirectoryPath> {
-    const config = await this.getBuildConfig();
+    const config = await this.buildContext.getBuildFileContents();
+    if (!config || !("generateVersionedPortal" in config)) {
+      return { isValid: false };
+    }
     const versionsPath = (config?.versionsPath as string) ?? "versioned_docs";
-    return this.buildDirectory.join(versionsPath);
-  }
-
-  public async getVersionDirectories(): Promise<DirectoryPath[]> {
-    const versionsDir = await this.getVersionsDirectory();
+    const versionsDir = this.buildDirectory.join(versionsPath);
     if (!(await this.fileService.directoryExists(versionsDir))) {
-      return [];
+      return { isValid: false };
     }
-    return await this.fileService.getSubDirectoriesPaths(versionsDir);
-  }
-
-  public async resolveVersionDirectory(apiVersion: string): Promise<DirectoryPath | null> {
-    const versionDirs = await this.getVersionDirectories();
-    return versionDirs.find((dir) => dir.leafName() === apiVersion) ?? null;
+    const versionsDirs = await this.fileService.getSubDirectoriesPaths(versionsDir);
+    const versions = versionsDirs.map((dir) => dir.leafName());
+    return { isValid: true, versionsDirectory: versionsDir, versions: versions };
   }
 }


### PR DESCRIPTION
Closes #249 

What was added?

- Added optional `api-version` flag to `sdk generate` to allow selecting the API version for multi-versioned builds.