### PR TITLE
fix: simplify portal serve caching logic and fix debounce scheduling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@apimatic/cli",
-    "version": "1.1.0-beta.8",
+    "version": "1.1.0-beta.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@apimatic/cli",
-            "version": "1.1.0-beta.8",
+            "version": "1.1.0-beta.9",
             "license": "MIT",
             "dependencies": {
                 "@apimatic/sdk": "^0.2.0-alpha.7",

--- a/src/actions/portal/serve.ts
+++ b/src/actions/portal/serve.ts
@@ -2,8 +2,6 @@ import { createServer as createLiveReloadServer } from "livereload";
 import connectLiveReload from "connect-livereload";
 import express, { Express } from "express";
 import chokidar from "chokidar";
-import crypto from "crypto";
-import { Mutex } from "async-mutex";
 import { PortalServePrompts } from "../../prompts/portal/serve.js";
 import { DirectoryPath } from "../../types/file/directoryPath.js";
 import { ActionResult } from "../action-result.js";
@@ -86,10 +84,6 @@ export class PortalServeAction {
     });
 
     const deletedDirectories = new Set<string>();
-    // TODO: Verify if we need mutex and eventQueue after refactoring.
-    const eventQueue = new Map();
-    const mutex = new Mutex();
-
     const debounceService: DebounceService = new DebounceService();
 
     watcher
@@ -105,22 +99,10 @@ export class PortalServeAction {
             }
           }
         }
-        const eventId: string = `${Date.now()}-${crypto.randomUUID()}`;
-        await mutex.runExclusive(async () => {
-          eventQueue.clear();
-          eventQueue.set(eventId, path);
-        });
 
         await debounceService.batchSingleRequest(async () => {
           this.prompts.changesDetected();
-
-          // TODO: Verify if this is needed.
-          if (!eventQueue.has(eventId)) {
-            return;
-          }
-
           await generatePortalAction.execute(buildDirectory, portalDirectory, true, false, false);
-
           liveReloadServer.refresh(portalDirectory.toString());
           this.clearStandardInput();
         });

--- a/src/infrastructure/debounce-service.ts
+++ b/src/infrastructure/debounce-service.ts
@@ -46,6 +46,9 @@ export class DebounceService {
         }
       } finally {
         this.isProcessing = false;
+        if (this.latestHandler) {
+          this.scheduleExecution();
+        }
       }
     }, this.debounceMs);
   }


### PR DESCRIPTION
## Summary
- Remove unnecessary mutex and event queue from `portal serve` action — these were left over from a prior implementation and no longer needed after the `DebounceService` refactor
- Fix `DebounceService` to reschedule execution if a new handler arrives while the current one is still processing, preventing missed updates

## Test plan
- [ ] Run `apimatic portal serve` and make rapid successive file changes — verify the portal rebuilds and live-reloads correctly without duplicate or missed builds
- [ ] Verify no regressions in normal single-change flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)