### PR TITLE
fix: pass package settings directory only when package settings applied

### DIFF
--- a/src/actions/sdk/publish.ts
+++ b/src/actions/sdk/publish.ts
@@ -39,11 +39,13 @@ export class SdkPublishAction {
   ): Promise<ActionResult<PublishingInfo>> => {
     return await withDirPath(async (tempDirectory) => {
       const packageConfiguration = publishingProfile.getPackageConfigurationForLanguage(language);
+      let packageSettingsTempDirectory: DirectoryPath | undefined;
       if (packageConfiguration !== null && packageConfiguration.isEnabled) {
         const packageSettingsConfiguration = PackageSettingsConfiguration.create(language, packageConfiguration);
         const packageSettingsDirectory = tempDirectory.join('package-settings');
         const packageSettingsContext = new PackageSettingsContext(packageSettingsDirectory);
         await packageSettingsContext.writeConfiguration(packageSettingsConfiguration, language);
+        packageSettingsTempDirectory = tempDirectory;
       }
 
       const sdkGenerateAction = new GenerateAction(this.configDir, this.commandMetadata);
@@ -57,7 +59,7 @@ export class SdkPublishAction {
         false,
         undefined,
         semVersion,
-        tempDirectory
+        packageSettingsTempDirectory
       );
       if (sdkGenerationResult.isFailed()) {
         return ActionResult.failed();

--- a/src/actions/sdk/publish.ts
+++ b/src/actions/sdk/publish.ts
@@ -39,13 +39,13 @@ export class SdkPublishAction {
   ): Promise<ActionResult<PublishingInfo>> => {
     return await withDirPath(async (tempDirectory) => {
       const packageConfiguration = publishingProfile.getPackageConfigurationForLanguage(language);
-      let packageSettingsTempDirectory: DirectoryPath | undefined;
+      let packageSettingsDirectory: DirectoryPath | undefined;
+
       if (packageConfiguration !== null && packageConfiguration.isEnabled) {
         const packageSettingsConfiguration = PackageSettingsConfiguration.create(language, packageConfiguration);
-        const packageSettingsDirectory = tempDirectory.join('package-settings');
+        packageSettingsDirectory = tempDirectory.join('package-settings');
         const packageSettingsContext = new PackageSettingsContext(packageSettingsDirectory);
         await packageSettingsContext.writeConfiguration(packageSettingsConfiguration, language);
-        packageSettingsTempDirectory = tempDirectory;
       }
 
       const sdkGenerateAction = new GenerateAction(this.configDir, this.commandMetadata);
@@ -59,7 +59,7 @@ export class SdkPublishAction {
         false,
         undefined,
         semVersion,
-        packageSettingsTempDirectory
+        packageSettingsDirectory
       );
       if (sdkGenerationResult.isFailed()) {
         return ActionResult.failed();

--- a/src/infrastructure/env-info.ts
+++ b/src/infrastructure/env-info.ts
@@ -57,7 +57,7 @@ class EnvInfo {
     const envBaseUrls = process.env.APIMATIC_BASE_URL;
     if (envBaseUrls) {
       const baseUrls = envBaseUrls.split(';');
-      EnvInfo.cachedAuthBaseUrl = baseUrls.length === 2 ? baseUrls[1] : undefined;
+      EnvInfo.cachedAuthBaseUrl = baseUrls.length === 3 ? baseUrls[1] : undefined;
     }
     return EnvInfo.cachedAuthBaseUrl;
   }

--- a/src/types/build-context.ts
+++ b/src/types/build-context.ts
@@ -52,7 +52,7 @@ export class BuildContext {
     const tempBuildDir = tempDir.join("build");
     await this.fileService.copyDirectoryContents(this.buildDirectory, tempBuildDir);
     if (packageSettingsDirectory) {
-      await this.fileService.copyDirectoryContents(packageSettingsDirectory.join('package-settings'), tempBuildDir.join('package-settings'));
+      await this.fileService.copyDirectoryContents(packageSettingsDirectory, tempBuildDir.join('package-settings'));
     }
     return await tempContext.zip(tempBuildDir);
   }


### PR DESCRIPTION
What was Changed?

- Added a fix for only passing package settings directory when they were applied.