### PR TITLE
feat: carry structured error codes on forbidden ServiceError

### DIFF
--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -24,8 +24,8 @@ export class ServiceError {
   static badRequest(customMessage: string, errors: Record<string, string[]>): ServiceError {
     return new ServiceError(ServiceErrorCode.BadRequest, customMessage, errors);
   }
-  static forbidden(customMessage: string): ServiceError {
-    return new ServiceError(ServiceErrorCode.Forbidden, customMessage, {});
+  static forbidden(customMessage: string, errors: Record<string, string[]> = {}): ServiceError {
+    return new ServiceError(ServiceErrorCode.Forbidden, customMessage, errors);
   }
   static notFound(customMessage: string): ServiceError {
     return new ServiceError(ServiceErrorCode.NotFound, customMessage, {});
@@ -51,6 +51,15 @@ export class ServiceError {
 
   public getError(key: string): string[] | undefined {
     return this.errors[key];
+  }
+
+  /**
+   * The keys of the structured errors map. For subscription failures the
+   * backend uses these as stable machine codes (e.g. "EndpointLimitExceeded",
+   * "FeatureNotAllowed"), letting consumers classify without parsing the message.
+   */
+  public get errorCodes(): string[] {
+    return Object.keys(this.errors);
   }
 }
 

--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -75,7 +75,7 @@ export class PortalService {
           return err(ServiceError.badRequest(errorMessage, errors));
         }
         if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
+          return err(ServiceError.forbidden(errorMessage, errors));
         }
       }
       const serviceError = handleServiceError(error);
@@ -112,7 +112,7 @@ export class PortalService {
         // TODO: This only picks the first error message, improve it to show all errors.
         const message = Object.values(errors)[0]?.[0] ?? null;
         const errorMessage = "Access denied to resource." + "\n- " + message;
-        return err(ServiceError.forbidden(errorMessage));
+        return err(ServiceError.forbidden(errorMessage, errors));
       }
     } while (statusResult.value.status !== Status.Completed);
 
@@ -164,7 +164,7 @@ export class PortalService {
           return err(ServiceError.badRequest(errorMessage, errors));
         }
         if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
+          return err(ServiceError.forbidden(errorMessage, errors));
         }
       }
       const serviceError = handleServiceError(error);
@@ -210,7 +210,7 @@ export class PortalService {
         const errors = statusResult.value.errors as Record<string, string[]>;
         const message = Object.values(errors).flat()[0] ?? null;
         const errorMessage = "Access denied to resource." + "\n- " + message;
-        return err(ServiceError.forbidden(errorMessage));
+        return err(ServiceError.forbidden(errorMessage, errors));
       }
     } while (statusResult.value.status !== Status.Completed);
 
@@ -262,7 +262,7 @@ export class PortalService {
           return err(ServiceError.badRequest(errorMessage, errors));
         }
         if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
+          return err(ServiceError.forbidden(errorMessage, errors));
         }
       }
       const serviceError = handleServiceError(error);
@@ -298,7 +298,7 @@ export class PortalService {
         const errors = statusResult.value.errors as Record<string, string[]>;
         const message = Object.values(errors).flat()[0] ?? null;
         const errorMessage = 'Access denied to resource.' + '\n- ' + message;
-        return err(ServiceError.forbidden(errorMessage));
+        return err(ServiceError.forbidden(errorMessage, errors));
       }
     } while (statusResult.value.status !== Status.Completed);
 


### PR DESCRIPTION
Codegen now keys subscription failures by a stable code (EndpointLimitExceeded / FeatureNotAllowed) in the errors dictionary. ServiceError.forbidden previously dropped that dictionary (passed {}); it now accepts and stores it (like badRequest), adds an errorCodes getter, and PortalService passes the errors through on the portal, SDK and v4-SDK paths (initial 403 + async SubscriptionError). Consumers can read error.errorCodes / error.getError(code) instead of parsing the message. Backwards compatible; tsc -b clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)