### PR TITLE
build: local dev scripts

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -26,7 +26,9 @@ pnpm test              # tsx + mocha, runs test/**/*.test.ts
 pnpm exec tsx node_modules/mocha/bin/_mocha "test/actions/portal/serve.test.ts" --timeout 99999
 
 # Run CLI locally
-node bin/run.js <command>
+pnpm build:watch       # tsc -b --watch: recompiles src/ → lib/ on change; keep running in a separate terminal
+pnpm apimatic <command>
+pnpm apimatic <command> -i <abs-path-to-dir-containing-src>   # -i: for commands operating on a project directory containing src/
 ```
 
 ## Adding / upgrading dependencies

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "types": "lib/index.d.ts",
     "scripts": {
         "build": "tsc -b",
+        "build:watch": "tsc -b --watch",
+        "apimatic": "node ./bin/run.js",
         "postpack": "rimraf oclif.manifest.json",
         "posttest": "eslint . --ext .ts",
         "prettier": "prettier \"src/**/*.{js,ts}\"",


### PR DESCRIPTION
Run `pnpm build:watch` for hot reloads/rebuilds.
Run `pnpm apimatic <command>` just like any other command in production e.g. `pnpm apimatic auth login`.