### PR TITLE
feat: surface API 401 error message with login suggestion in portal generation

### DIFF
--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { ApiError } from "@apimatic/sdk";
 import { format as f } from "../prompts/format.js";
 
 export enum ServiceErrorCode {
@@ -63,6 +64,15 @@ export class ServiceError {
 }
 
 export function handleServiceError(error: unknown): ServiceError {
+  // SDK controllers throw typed `ApiError`s (not axios errors). The API reports
+  // the reason as {"message": "..."} deserialized into `result`.
+  if (error instanceof ApiError) {
+    const apiMessage = (error.result as { message?: string } | undefined)?.message ?? null;
+    if (error.statusCode === 401) return ServiceError.unauthorized(apiMessage);
+    if (error.statusCode === 404) return ServiceError.NotFound;
+    if (error.statusCode === 500) return ServiceError.ServerError;
+  }
+
   if (axios.isAxiosError(error)) {
     const status = error.response?.status;
     if (status === 401) return ServiceError.UnAuthorized;

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -63,15 +63,19 @@ export class ServiceError {
   }
 }
 
-export function handleServiceError(error: unknown): ServiceError {
-  // SDK controllers throw typed `ApiError`s (not axios errors). The API reports
-  // the reason as {"message": "..."} deserialized into `result`.
-  if (error instanceof ApiError) {
+// SDK controllers throw typed `ApiError`s (not axios errors). The API reports
+// the reason as {"message": "..."} deserialized into `result`.
+function mapApiError(error: ApiError): ServiceError {
+  if (error.statusCode === 401) {
     const apiMessage = (error.result as { message?: string } | undefined)?.message ?? null;
-    if (error.statusCode === 401) return ServiceError.unauthorized(apiMessage);
-    if (error.statusCode === 404) return ServiceError.NotFound;
-    if (error.statusCode === 500) return ServiceError.ServerError;
+    return ServiceError.unauthorized(apiMessage);
   }
+  if (error.statusCode === 404) return ServiceError.NotFound;
+  return ServiceError.ServerError;
+}
+
+export function handleServiceError(error: unknown): ServiceError {
+  if (error instanceof ApiError) return mapApiError(error);
 
   if (axios.isAxiosError(error)) {
     const status = error.response?.status;

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -30,6 +30,14 @@ export class ServiceError {
   static notFound(customMessage: string): ServiceError {
     return new ServiceError(ServiceErrorCode.NotFound, customMessage, {});
   }
+  static unauthorized(apiMessage: string | null): ServiceError {
+    const message = `${apiMessage ?? "You are not authorized to perform this action."} Please run ${f.cmdAlt(
+      "apimatic",
+      "auth",
+      "login"
+    )} to log in, or provide a valid auth key using the ${f.flag("auth-key")} flag.`;
+    return new ServiceError(ServiceErrorCode.UnAuthorized, message, {});
+  }
 
   static readonly values: ServiceError[] = [
     ServiceError.NotFound,

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -31,7 +31,7 @@ export class ServiceError {
   static notFound(customMessage: string): ServiceError {
     return new ServiceError(ServiceErrorCode.NotFound, customMessage, {});
   }
-  static unauthorized(apiMessage: string | null): ServiceError {
+  static unauthorizedWithHint(apiMessage: string | null): ServiceError {
     const message = `${apiMessage ?? "You are not authorized to perform this action."} Please run ${f.cmdAlt(
       "apimatic",
       "auth",
@@ -66,10 +66,13 @@ export class ServiceError {
 // A ProblemDetails body carries a `title` plus a map of field errors; surface
 // the title and the first field message.
 function mapProblemDetailsError(error: ProblemDetailsError): ServiceError | null {
+  // ProblemDetails.title and .errors are optional and result may be absent — guard
+  // all three so a sparse body can't crash or render a trailing "- null".
   // TODO: This only picks the first error message, improve it to show all errors.
-  const errors = error.result!.errors as Record<string, string[]>;
-  const message = Object.values(errors)[0]?.[0] ?? null;
-  const errorMessage = error.result!.title + "\n- " + message;
+  const errors = (error.result?.errors ?? {}) as Record<string, string[]>;
+  const firstFieldMessage = Object.values(errors)[0]?.[0];
+  const title = error.result?.title ?? "Request failed.";
+  const errorMessage = firstFieldMessage ? `${title}\n- ${firstFieldMessage}` : title;
   if (error.statusCode === 400) return ServiceError.badRequest(errorMessage, errors);
   if (error.statusCode === 403) return ServiceError.forbidden(errorMessage);
   return null;
@@ -84,7 +87,7 @@ function mapApiError(error: ApiError): ServiceError {
   }
   if (error.statusCode === 401) {
     const apiMessage = (error.result as { message?: string } | undefined)?.message ?? null;
-    return ServiceError.unauthorized(apiMessage);
+    return ServiceError.unauthorizedWithHint(apiMessage);
   }
   if (error.statusCode === 404) return ServiceError.NotFound;
   return ServiceError.ServerError;

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ApiError } from "@apimatic/sdk";
+import { ApiError, ProblemDetailsError } from "@apimatic/sdk";
 import { format as f } from "../prompts/format.js";
 
 export enum ServiceErrorCode {
@@ -63,9 +63,25 @@ export class ServiceError {
   }
 }
 
+// A ProblemDetails body carries a `title` plus a map of field errors; surface
+// the title and the first field message.
+function mapProblemDetailsError(error: ProblemDetailsError): ServiceError | null {
+  // TODO: This only picks the first error message, improve it to show all errors.
+  const errors = error.result!.errors as Record<string, string[]>;
+  const message = Object.values(errors)[0]?.[0] ?? null;
+  const errorMessage = error.result!.title + "\n- " + message;
+  if (error.statusCode === 400) return ServiceError.badRequest(errorMessage, errors);
+  if (error.statusCode === 403) return ServiceError.forbidden(errorMessage);
+  return null;
+}
+
 // SDK controllers throw typed `ApiError`s (not axios errors). The API reports
 // the reason as {"message": "..."} deserialized into `result`.
 function mapApiError(error: ApiError): ServiceError {
+  if (error instanceof ProblemDetailsError) {
+    const serviceError = mapProblemDetailsError(error);
+    if (serviceError) return serviceError;
+  }
   if (error.statusCode === 401) {
     const apiMessage = (error.result as { message?: string } | undefined)?.message ?? null;
     return ServiceError.unauthorized(apiMessage);

--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -74,9 +74,15 @@ export class PortalService {
         if (error.statusCode === 400) {
           return err(ServiceError.badRequest(errorMessage, errors));
         }
-        if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
+        if (error.statusCode === 401) {
+          return err(ServiceError.UnAuthorized);
         }
+      }
+      if (error instanceof ApiError && error.statusCode === 401) {
+        // The API reports the reason as {"message": "..."} which the SDK
+        // deserializes into `result` for its typed 401 error.
+        const apiMessage = (error.result as { message?: string } | undefined)?.message ?? null;
+        return err(ServiceError.unauthorized(apiMessage));
       }
       const serviceError = handleServiceError(error);
       return err(serviceError);

--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -6,7 +6,6 @@ import {
   ContentType,
   DocsPortalGenerationAsyncController,
   SdkSourceTreeGenerationAsyncController,
-  ProblemDetailsError,
   FileWrapper,
   TransformationController,
   Transformation,
@@ -66,21 +65,8 @@ export class PortalService {
       );
       generationId = portalInstance.result.id;
     } catch (error) {
-      if (error instanceof ProblemDetailsError) {
-        const errors = error.result!.errors as Record<string, string[]>;
-        // TODO: This only picks the first error message, improve it to show all errors.
-        const message = Object.values(errors)[0]?.[0] ?? null;
-        const errorMessage = error.result!.title + "\n- " + message;
-        if (error.statusCode === 400) {
-          return err(ServiceError.badRequest(errorMessage, errors));
-        }
-        if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
-        }
-      }
-      // 401 (and other SDK ApiError statuses) are mapped centrally in handleServiceError.
-      const serviceError = handleServiceError(error);
-      return err(serviceError);
+      // ProblemDetails (400/403), 401 and other SDK statuses are mapped centrally.
+      return err(handleServiceError(error));
     } finally {
       buildFileStream.close();
     }
@@ -156,20 +142,7 @@ export class PortalService {
       );
       generationId = response.result.id;
     } catch (error) {
-      if (error instanceof ProblemDetailsError) {
-        // TODO: This only picks the first error message, improve it to show all errors.
-        const errors = error.result!.errors as Record<string, string[]>;
-        const message = Object.values(errors)[0]?.[0] ?? null;
-        const errorMessage = error.result!.title + "\n- " + message;
-        if (error.statusCode === 400) {
-          return err(ServiceError.badRequest(errorMessage, errors));
-        }
-        if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
-        }
-      }
-      const serviceError = handleServiceError(error);
-      return err(serviceError);
+      return err(handleServiceError(error));
     } finally {
       buildFileStream.close();
     }
@@ -254,20 +227,7 @@ export class PortalService {
       );
       generationId = response.result.id;
     } catch (error) {
-      if (error instanceof ProblemDetailsError) {
-        // TODO: This only picks the first error message, improve it to show all errors.
-        const errors = error.result!.errors as Record<string, string[]>;
-        const message = Object.values(errors)[0]?.[0] ?? null;
-        const errorMessage = error.result!.title + '\n- ' + message;
-        if (error.statusCode === 400) {
-          return err(ServiceError.badRequest(errorMessage, errors));
-        }
-        if (error.statusCode === 403) {
-          return err(ServiceError.forbidden(errorMessage));
-        }
-      }
-      const serviceError = handleServiceError(error);
-      return err(serviceError);
+      return err(handleServiceError(error));
     } finally {
       buildFileStream.close();
     }

--- a/src/infrastructure/services/portal-service.ts
+++ b/src/infrastructure/services/portal-service.ts
@@ -74,16 +74,11 @@ export class PortalService {
         if (error.statusCode === 400) {
           return err(ServiceError.badRequest(errorMessage, errors));
         }
-        if (error.statusCode === 401) {
-          return err(ServiceError.UnAuthorized);
+        if (error.statusCode === 403) {
+          return err(ServiceError.forbidden(errorMessage));
         }
       }
-      if (error instanceof ApiError && error.statusCode === 401) {
-        // The API reports the reason as {"message": "..."} which the SDK
-        // deserializes into `result` for its typed 401 error.
-        const apiMessage = (error.result as { message?: string } | undefined)?.message ?? null;
-        return err(ServiceError.unauthorized(apiMessage));
-      }
+      // 401 (and other SDK ApiError statuses) are mapped centrally in handleServiceError.
       const serviceError = handleServiceError(error);
       return err(serviceError);
     } finally {


### PR DESCRIPTION
## Problem

Running portal commands without a valid session (e.g. `apimatic portal serve` while logged out) showed the generic fallback:

> An unexpected error occurred, please try again later. If the problem persists, please reach out to our team at support@apimatic.io

even though the API returns a clear reason (`{"message": "Authorization has been denied for this request."}`). The SDK throws its typed `UnauthorizedResponseError` for 401s, but `handleServiceError` only recognizes axios errors, so the  generic `ServerError`.

## Changes

- **`portal-service.ts`**: In `generatePortal`'s catch, handle `ApiError` with status 401 — extract the API's message from the deserialized error `result` and return a `ServiceError` that pairs it with a suggested fix. All other errors continue to flow through `handleServiceError` unchanged (kept scoped on purpose; message handling differs per flow).

- **`service-error.ts`**: New `ServiceError.unauthorized(apiMessage)` factory (alongside `badRequest`/`forbidden`/`notFound`) that appends "run `apimatic auth login` or provide a valid auth key using the `--auth-key` flag" to the API's message.

## Result

■  Portal Generation failed.
■  Authorization has been denied for this request. Please
   to log in, or provide a valid auth key using the --auth-key flag.


## Testing

- Reproduced end-to-end: `portal serve` with an empty config dir (logged out) against the production API — enhanced message shown.
- Verified the axios 401 path is unaffected: `auth status` with an invalid stored key still prints "Invalid API key provided." (relies on the `ServiceError.UnAuthorized` singleton identity check, which is preserved).
- `pnpm test`: 45 passing, lint clean.
