### PR TITLE
feat: AI-first messaging and Copilot-aware portal quickstart next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install -g @apimatic/cli
 $ apimatic COMMAND
 running command...
 $ apimatic (--version)
-@apimatic/cli/1.1.0-beta.16 win32-x64 node-v23.4.0
+@apimatic/cli/1.1.0 win32-x64 node-v24.14.1
 $ apimatic --help [COMMAND]
 USAGE
   $ apimatic COMMAND
@@ -53,7 +53,7 @@ USAGE
 
 ## `apimatic api transform`
 
-Transform API specifications between different formats.
+Transform API specifications between different formats
 
 ```
 USAGE
@@ -62,17 +62,17 @@ USAGE
     0|graphqlschema [--file <value>] [--url <value>] [-d <value>] [-f] [-k <value>]
 
 FLAGS
-  -d, --destination=<value>  [default: ./] directory to save the transformed file to
+  -d, --destination=<value>  [default: ./] Directory to save the transformed file to
   -f, --force                overwrite changes without asking for user consent.
   -k, --auth-key=<value>     override current authentication state with an authentication key.
-      --file=<value>         path to the API specification file to transform
-      --format=<option>      (required) specification format to transform API specification into
+      --file=<value>         Path to the API specification file to transform
+      --format=<option>      (required) Specification format to transform API specification into
                              <options: apimatic|wadl2009|wsdl|swagger10|swagger20|swaggeryaml|oas3|openapi3yaml|apibluep
                              rint|raml|raml10|postman10|postman20|graphqlschema>
       --url=<value>          URL to the API specification file to transform (publicly accessible)
 
 DESCRIPTION
-  Transform API specifications between different formats.
+  Transform API specifications between different formats
 
   Transform API specifications from one format to another.
   Supports multiple formats including OpenAPI/Swagger, RAML, WSDL, and Postman Collections.
@@ -83,11 +83,11 @@ EXAMPLES
   apimatic api transform --format=raml --url="https://petstore.swagger.io/v2/swagger.json" --destination=./
 ```
 
-_See code: [src/commands/api/transform.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/api/transform.ts)_
+_See code: [src/commands/api/transform.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/api/transform.ts)_
 
 ## `apimatic api validate`
 
-Validate API specification for syntactic and semantic correctness.
+Validate API specification for syntactic and semantic correctness
 
 ```
 USAGE
@@ -99,7 +99,7 @@ FLAGS
       --url=<value>       URL to the API specification file to validate (publicly accessible)
 
 DESCRIPTION
-  Validate API specification for syntactic and semantic correctness.
+  Validate API specification for syntactic and semantic correctness
 
   Validate your API specification to ensure it adheres to syntactic and semantic standards.
 
@@ -109,11 +109,11 @@ EXAMPLES
   apimatic api validate --url="https://petstore.swagger.io/v2/swagger.json"
 ```
 
-_See code: [src/commands/api/validate.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/api/validate.ts)_
+_See code: [src/commands/api/validate.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/api/validate.ts)_
 
 ## `apimatic auth login`
 
-Login to your APIMatic account.
+Login to your APIMatic account
 
 ```
 USAGE
@@ -123,7 +123,7 @@ FLAGS
   -k, --auth-key=<value>  Sets authentication key for all commands.
 
 DESCRIPTION
-  Login to your APIMatic account.
+  Login to your APIMatic account
 
   Login using your APIMatic credentials or an API Key
 
@@ -133,7 +133,7 @@ EXAMPLES
   apimatic auth login --auth-key={api-key}
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/auth/login.ts)_
 
 ## `apimatic auth logout`
 
@@ -152,7 +152,7 @@ EXAMPLES
   apimatic auth logout
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/auth/logout.ts)_
+_See code: [src/commands/auth/logout.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/auth/logout.ts)_
 
 ## `apimatic auth status`
 
@@ -169,7 +169,7 @@ EXAMPLES
   apimatic auth status
 ```
 
-_See code: [src/commands/auth/status.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/auth/status.ts)_
+_See code: [src/commands/auth/status.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/auth/status.ts)_
 
 ## `apimatic autocomplete [SHELL]`
 
@@ -180,7 +180,7 @@ USAGE
   $ apimatic autocomplete [SHELL] [-r]
 
 ARGUMENTS
-  SHELL  (zsh|bash|powershell) Shell type
+  [SHELL]  (zsh|bash|powershell) Shell type
 
 FLAGS
   -r, --refresh-cache  Refresh cache (ignores displaying instructions)
@@ -200,7 +200,7 @@ EXAMPLES
   $ apimatic autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/main/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.2.47/src/commands/autocomplete/index.ts)_
 
 ## `apimatic help [COMMAND]`
 
@@ -211,7 +211,7 @@ USAGE
   $ apimatic help [COMMAND...] [-n]
 
 ARGUMENTS
-  COMMAND...  Command to show help for.
+  [COMMAND...]  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.
@@ -220,7 +220,7 @@ DESCRIPTION
   Display help for apimatic.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/main/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.46/src/commands/help.ts)_
 
 ## `apimatic portal copilot`
 
@@ -250,11 +250,11 @@ EXAMPLES
   apimatic portal copilot --input=./ --disable
 ```
 
-_See code: [src/commands/portal/copilot.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/copilot.ts)_
+_See code: [src/commands/portal/copilot.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/copilot.ts)_
 
 ## `apimatic portal generate`
 
-Generate an API Documentation portal.
+Generate Context Plugins, API Documentation Portal with AI Assist Features.
 
 ```
 USAGE
@@ -266,10 +266,10 @@ FLAGS
   -i, --input=<value>        [default: ./] path to the parent directory containing the 'src' directory, which includes
                              API specifications and configuration files.
   -k, --auth-key=<value>     override current authentication state with an authentication key.
-      --zip                  download the generated portal as a .zip archive
+      --zip                  Download the generated portal as a .zip archive
 
 DESCRIPTION
-  Generate an API Documentation portal.
+  Generate Context Plugins, API Documentation Portal with AI Assist Features.
 
   Generate an API Documentation portal. Requires an input directory containing API specifications, a config file and
   optionally, markdown guides. For details, refer to the [documentation](https://docs.apimatic.io/platform-api/#/http/gu
@@ -281,7 +281,7 @@ EXAMPLES
   apimatic portal generate --input="./" --destination="./portal"
 ```
 
-_See code: [src/commands/portal/generate.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/generate.ts)_
+_See code: [src/commands/portal/generate.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/generate.ts)_
 
 ## `apimatic portal recipe new`
 
@@ -308,10 +308,10 @@ DESCRIPTION
 EXAMPLES
   apimatic portal recipe new
 
-  apimatic portal recipe new --name="My API Recipe" --input="./"
+  apimatic portal recipe new --name='"My API Recipe"' --input="./"
 ```
 
-_See code: [src/commands/portal/recipe/new.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/recipe/new.ts)_
+_See code: [src/commands/portal/recipe/new.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/recipe/new.ts)_
 
 ## `apimatic portal serve`
 
@@ -319,7 +319,7 @@ Generate and serve an API Documentation Portal with hot reload.
 
 ```
 USAGE
-  $ apimatic portal serve [-p 3000] [-i <value>] [-d <value>] [-o] [--no-reload] [-k <value>]
+  $ apimatic portal serve [-p 23513] [-i <value>] [-d <value>] [-o] [--no-reload] [-k <value>]
 
 FLAGS
   -d, --destination=<value>  [default: <input>/portal] path where the portal will be generated.
@@ -327,7 +327,7 @@ FLAGS
                              API specifications and configuration files.
   -k, --auth-key=<value>     override current authentication state with an authentication key.
   -o, --open                 open the portal in the default browser.
-  -p, --port=3000            [default: 3000] port to serve the portal.
+  -p, --port=23513           [default: 23513] port to serve the portal.
       --no-reload            disable hot reload.
 
 DESCRIPTION
@@ -339,10 +339,10 @@ DESCRIPTION
 EXAMPLES
   apimatic portal serve
 
-  apimatic portal serve --input=./ --destination=./portal --port=3000 --open --no-reload
+  apimatic portal serve --input=./ --destination=./portal --port=23513 --open --no-reload
 ```
 
-_See code: [src/commands/portal/serve.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/serve.ts)_
+_See code: [src/commands/portal/serve.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/serve.ts)_
 
 ## `apimatic portal toc new`
 
@@ -386,7 +386,7 @@ EXAMPLES
   apimatic portal toc new --input=./ --destination=./src/content/
 ```
 
-_See code: [src/commands/portal/toc/new.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/toc/new.ts)_
+_See code: [src/commands/portal/toc/new.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/toc/new.ts)_
 
 ## `apimatic publishing profile list`
 
@@ -405,18 +405,18 @@ EXAMPLES
   apimatic publishing profile list
 ```
 
-_See code: [src/commands/publishing/profile/list.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/publishing/profile/list.ts)_
+_See code: [src/commands/publishing/profile/list.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/publishing/profile/list.ts)_
 
 ## `apimatic quickstart`
 
-Create your first SDK or API Portal using APIMatic.
+Create your first Context Plugins, API Portal or SDK using APIMatic.
 
 ```
 USAGE
   $ apimatic quickstart
 
 DESCRIPTION
-  Create your first SDK or API Portal using APIMatic.
+  Create your first Context Plugins, API Portal or SDK using APIMatic.
 
   Get started with your first SDK or API Portal in four easy steps.
 
@@ -424,7 +424,7 @@ EXAMPLES
   apimatic quickstart
 ```
 
-_See code: [src/commands/quickstart.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/quickstart.ts)_
+_See code: [src/commands/quickstart.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/quickstart.ts)_
 
 ## `apimatic sdk generate`
 
@@ -468,7 +468,7 @@ EXAMPLES
   apimatic sdk generate --language=python --destination=./sdk --zip
 ```
 
-_See code: [src/commands/sdk/generate.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/sdk/generate.ts)_
+_See code: [src/commands/sdk/generate.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/sdk/generate.ts)_
 
 ## `apimatic sdk publish`
 
@@ -510,7 +510,7 @@ EXAMPLES
   apimatic sdk publish --profile-id=c3d4e5f6a1b2c3d4e5f6a1b2 --language=python --version=1.0.0 --publish-type=package --dry-run
 ```
 
-_See code: [src/commands/sdk/publish.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/sdk/publish.ts)_
+_See code: [src/commands/sdk/publish.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/sdk/publish.ts)_
 
 ## `apimatic sdk save-changes`
 
@@ -542,5 +542,5 @@ EXAMPLES
   apimatic sdk save-changes --language=java --sdk=./sdk
 ```
 
-_See code: [src/commands/sdk/save-changes.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/sdk/save-changes.ts)_
+_See code: [src/commands/sdk/save-changes.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/sdk/save-changes.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install -g @apimatic/cli
 $ apimatic COMMAND
 running command...
 $ apimatic (--version)
-@apimatic/cli/1.1.0 win32-x64 node-v24.14.1
+@apimatic/cli/1.1.0-beta.16 win32-x64 node-v23.4.0
 $ apimatic --help [COMMAND]
 USAGE
   $ apimatic COMMAND
@@ -53,7 +53,7 @@ USAGE
 
 ## `apimatic api transform`
 
-Transform API specifications between different formats
+Transform API specifications between different formats.
 
 ```
 USAGE
@@ -62,17 +62,17 @@ USAGE
     0|graphqlschema [--file <value>] [--url <value>] [-d <value>] [-f] [-k <value>]
 
 FLAGS
-  -d, --destination=<value>  [default: ./] Directory to save the transformed file to
+  -d, --destination=<value>  [default: ./] directory to save the transformed file to
   -f, --force                overwrite changes without asking for user consent.
   -k, --auth-key=<value>     override current authentication state with an authentication key.
-      --file=<value>         Path to the API specification file to transform
-      --format=<option>      (required) Specification format to transform API specification into
+      --file=<value>         path to the API specification file to transform
+      --format=<option>      (required) specification format to transform API specification into
                              <options: apimatic|wadl2009|wsdl|swagger10|swagger20|swaggeryaml|oas3|openapi3yaml|apibluep
                              rint|raml|raml10|postman10|postman20|graphqlschema>
       --url=<value>          URL to the API specification file to transform (publicly accessible)
 
 DESCRIPTION
-  Transform API specifications between different formats
+  Transform API specifications between different formats.
 
   Transform API specifications from one format to another.
   Supports multiple formats including OpenAPI/Swagger, RAML, WSDL, and Postman Collections.
@@ -83,11 +83,11 @@ EXAMPLES
   apimatic api transform --format=raml --url="https://petstore.swagger.io/v2/swagger.json" --destination=./
 ```
 
-_See code: [src/commands/api/transform.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/api/transform.ts)_
+_See code: [src/commands/api/transform.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/api/transform.ts)_
 
 ## `apimatic api validate`
 
-Validate API specification for syntactic and semantic correctness
+Validate API specification for syntactic and semantic correctness.
 
 ```
 USAGE
@@ -99,7 +99,7 @@ FLAGS
       --url=<value>       URL to the API specification file to validate (publicly accessible)
 
 DESCRIPTION
-  Validate API specification for syntactic and semantic correctness
+  Validate API specification for syntactic and semantic correctness.
 
   Validate your API specification to ensure it adheres to syntactic and semantic standards.
 
@@ -109,11 +109,11 @@ EXAMPLES
   apimatic api validate --url="https://petstore.swagger.io/v2/swagger.json"
 ```
 
-_See code: [src/commands/api/validate.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/api/validate.ts)_
+_See code: [src/commands/api/validate.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/api/validate.ts)_
 
 ## `apimatic auth login`
 
-Login to your APIMatic account
+Login to your APIMatic account.
 
 ```
 USAGE
@@ -123,7 +123,7 @@ FLAGS
   -k, --auth-key=<value>  Sets authentication key for all commands.
 
 DESCRIPTION
-  Login to your APIMatic account
+  Login to your APIMatic account.
 
   Login using your APIMatic credentials or an API Key
 
@@ -133,7 +133,7 @@ EXAMPLES
   apimatic auth login --auth-key={api-key}
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/auth/login.ts)_
 
 ## `apimatic auth logout`
 
@@ -152,7 +152,7 @@ EXAMPLES
   apimatic auth logout
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/auth/logout.ts)_
+_See code: [src/commands/auth/logout.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/auth/logout.ts)_
 
 ## `apimatic auth status`
 
@@ -169,7 +169,7 @@ EXAMPLES
   apimatic auth status
 ```
 
-_See code: [src/commands/auth/status.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/auth/status.ts)_
+_See code: [src/commands/auth/status.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/auth/status.ts)_
 
 ## `apimatic autocomplete [SHELL]`
 
@@ -180,7 +180,7 @@ USAGE
   $ apimatic autocomplete [SHELL] [-r]
 
 ARGUMENTS
-  [SHELL]  (zsh|bash|powershell) Shell type
+  SHELL  (zsh|bash|powershell) Shell type
 
 FLAGS
   -r, --refresh-cache  Refresh cache (ignores displaying instructions)
@@ -200,7 +200,7 @@ EXAMPLES
   $ apimatic autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.2.47/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/main/src/commands/autocomplete/index.ts)_
 
 ## `apimatic help [COMMAND]`
 
@@ -211,7 +211,7 @@ USAGE
   $ apimatic help [COMMAND...] [-n]
 
 ARGUMENTS
-  [COMMAND...]  Command to show help for.
+  COMMAND...  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.
@@ -220,7 +220,7 @@ DESCRIPTION
   Display help for apimatic.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.46/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/main/src/commands/help.ts)_
 
 ## `apimatic portal copilot`
 
@@ -250,11 +250,11 @@ EXAMPLES
   apimatic portal copilot --input=./ --disable
 ```
 
-_See code: [src/commands/portal/copilot.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/copilot.ts)_
+_See code: [src/commands/portal/copilot.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/copilot.ts)_
 
 ## `apimatic portal generate`
 
-Generate Context Plugins, API Documentation Portal with AI Assist Features.
+Generate an API Documentation portal.
 
 ```
 USAGE
@@ -266,10 +266,10 @@ FLAGS
   -i, --input=<value>        [default: ./] path to the parent directory containing the 'src' directory, which includes
                              API specifications and configuration files.
   -k, --auth-key=<value>     override current authentication state with an authentication key.
-      --zip                  Download the generated portal as a .zip archive
+      --zip                  download the generated portal as a .zip archive
 
 DESCRIPTION
-  Generate Context Plugins, API Documentation Portal with AI Assist Features.
+  Generate an API Documentation portal.
 
   Generate an API Documentation portal. Requires an input directory containing API specifications, a config file and
   optionally, markdown guides. For details, refer to the [documentation](https://docs.apimatic.io/platform-api/#/http/gu
@@ -281,7 +281,7 @@ EXAMPLES
   apimatic portal generate --input="./" --destination="./portal"
 ```
 
-_See code: [src/commands/portal/generate.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/generate.ts)_
+_See code: [src/commands/portal/generate.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/generate.ts)_
 
 ## `apimatic portal recipe new`
 
@@ -308,10 +308,10 @@ DESCRIPTION
 EXAMPLES
   apimatic portal recipe new
 
-  apimatic portal recipe new --name='"My API Recipe"' --input="./"
+  apimatic portal recipe new --name="My API Recipe" --input="./"
 ```
 
-_See code: [src/commands/portal/recipe/new.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/recipe/new.ts)_
+_See code: [src/commands/portal/recipe/new.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/recipe/new.ts)_
 
 ## `apimatic portal serve`
 
@@ -319,7 +319,7 @@ Generate and serve an API Documentation Portal with hot reload.
 
 ```
 USAGE
-  $ apimatic portal serve [-p 23513] [-i <value>] [-d <value>] [-o] [--no-reload] [-k <value>]
+  $ apimatic portal serve [-p 3000] [-i <value>] [-d <value>] [-o] [--no-reload] [-k <value>]
 
 FLAGS
   -d, --destination=<value>  [default: <input>/portal] path where the portal will be generated.
@@ -327,7 +327,7 @@ FLAGS
                              API specifications and configuration files.
   -k, --auth-key=<value>     override current authentication state with an authentication key.
   -o, --open                 open the portal in the default browser.
-  -p, --port=23513           [default: 23513] port to serve the portal.
+  -p, --port=3000            [default: 3000] port to serve the portal.
       --no-reload            disable hot reload.
 
 DESCRIPTION
@@ -339,10 +339,10 @@ DESCRIPTION
 EXAMPLES
   apimatic portal serve
 
-  apimatic portal serve --input=./ --destination=./portal --port=23513 --open --no-reload
+  apimatic portal serve --input=./ --destination=./portal --port=3000 --open --no-reload
 ```
 
-_See code: [src/commands/portal/serve.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/serve.ts)_
+_See code: [src/commands/portal/serve.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/serve.ts)_
 
 ## `apimatic portal toc new`
 
@@ -386,7 +386,7 @@ EXAMPLES
   apimatic portal toc new --input=./ --destination=./src/content/
 ```
 
-_See code: [src/commands/portal/toc/new.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/portal/toc/new.ts)_
+_See code: [src/commands/portal/toc/new.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/portal/toc/new.ts)_
 
 ## `apimatic publishing profile list`
 
@@ -405,18 +405,18 @@ EXAMPLES
   apimatic publishing profile list
 ```
 
-_See code: [src/commands/publishing/profile/list.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/publishing/profile/list.ts)_
+_See code: [src/commands/publishing/profile/list.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/publishing/profile/list.ts)_
 
 ## `apimatic quickstart`
 
-Create your first Context Plugins, API Portal or SDK using APIMatic.
+Create your first SDK or API Portal using APIMatic.
 
 ```
 USAGE
   $ apimatic quickstart
 
 DESCRIPTION
-  Create your first Context Plugins, API Portal or SDK using APIMatic.
+  Create your first SDK or API Portal using APIMatic.
 
   Get started with your first SDK or API Portal in four easy steps.
 
@@ -424,7 +424,7 @@ EXAMPLES
   apimatic quickstart
 ```
 
-_See code: [src/commands/quickstart.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/quickstart.ts)_
+_See code: [src/commands/quickstart.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/quickstart.ts)_
 
 ## `apimatic sdk generate`
 
@@ -468,7 +468,7 @@ EXAMPLES
   apimatic sdk generate --language=python --destination=./sdk --zip
 ```
 
-_See code: [src/commands/sdk/generate.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/sdk/generate.ts)_
+_See code: [src/commands/sdk/generate.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/sdk/generate.ts)_
 
 ## `apimatic sdk publish`
 
@@ -510,7 +510,7 @@ EXAMPLES
   apimatic sdk publish --profile-id=c3d4e5f6a1b2c3d4e5f6a1b2 --language=python --version=1.0.0 --publish-type=package --dry-run
 ```
 
-_See code: [src/commands/sdk/publish.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/sdk/publish.ts)_
+_See code: [src/commands/sdk/publish.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/sdk/publish.ts)_
 
 ## `apimatic sdk save-changes`
 
@@ -542,5 +542,5 @@ EXAMPLES
   apimatic sdk save-changes --language=java --sdk=./sdk
 ```
 
-_See code: [src/commands/sdk/save-changes.ts](https://github.com/apimatic/apimatic-cli/blob/v1.1.0/src/commands/sdk/save-changes.ts)_
+_See code: [src/commands/sdk/save-changes.ts](https://github.com/apimatic/apimatic-cli/blob/beta/src/commands/sdk/save-changes.ts)_
 <!-- commandsstop -->

--- a/src/actions/portal/quickstart.ts
+++ b/src/actions/portal/quickstart.ts
@@ -260,7 +260,7 @@ export class PortalQuickstartAction {
       const portalDirectory = inputDirectory.join('portal');
       const portalServeAction = new PortalServeAction(this.configDir, this.commandMetadata, null);
       const result = await portalServeAction.execute(sourceDirectory, portalDirectory, defaultPort, true, false, () => {
-        this.prompts.nextSteps();
+        this.prompts.nextSteps(prunedConfig.hasAiIntegration());
       });
 
       if (result.isFailed()) {

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -6,7 +6,7 @@ import { format, intro, outro } from "../../prompts/format.js";
 import { CommandMetadata } from "../../types/common/command-metadata.js";
 
 export class PortalGenerate extends Command {
-  static summary = "Generate Context Plugins, API Documentation Portal with AI Assist Features.";
+  static summary = "Generate API Documentation Portal with Context Plugins and AI Assist Features.";
 
   static description =
     "Generate an API Documentation portal. Requires an input directory containing API specifications, a config file and optionally, markdown guides. For details, refer to the [documentation](https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-portal/build-file-reference)";

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -6,7 +6,7 @@ import { format, intro, outro } from "../../prompts/format.js";
 import { CommandMetadata } from "../../types/common/command-metadata.js";
 
 export class PortalGenerate extends Command {
-  static summary = "Generate an API Documentation portal";
+  static summary = "Generate Context Plugins, API Documentation Portal with AI Assist Features.";
 
   static description =
     "Generate an API Documentation portal. Requires an input directory containing API specifications, a config file and optionally, markdown guides. For details, refer to the [documentation](https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-portal/build-file-reference)";

--- a/src/commands/portal/generate.ts
+++ b/src/commands/portal/generate.ts
@@ -6,7 +6,7 @@ import { format, intro, outro } from "../../prompts/format.js";
 import { CommandMetadata } from "../../types/common/command-metadata.js";
 
 export class PortalGenerate extends Command {
-  static summary = "Generate API Documentation Portal with Context Plugins and AI Assist Features.";
+  static summary = "Generate Context Plugins and API Documentation Portal with AI Assist Features.";
 
   static description =
     "Generate an API Documentation portal. Requires an input directory containing API specifications, a config file and optionally, markdown guides. For details, refer to the [documentation](https://docs.apimatic.io/platform-api/#/http/guides/generating-on-prem-api-portal/build-file-reference)";

--- a/src/commands/quickstart.ts
+++ b/src/commands/quickstart.ts
@@ -10,7 +10,7 @@ import { QuickstartCompletedEvent } from "../types/events/quickstart-completed.j
 export default class Quickstart extends Command {
   static description = "Get started with your first SDK or API Portal in four easy steps.";
 
-  static summary = "Create your first Context Plugins, API Portal or SDK using APIMatic.";
+  static summary = "Create your first API Portal with Context Plugins and SDKs, or a standalone SDK, using APIMatic.";
 
   static cmdTxt = format.cmd("apimatic", "quickstart");
 

--- a/src/commands/quickstart.ts
+++ b/src/commands/quickstart.ts
@@ -10,7 +10,7 @@ import { QuickstartCompletedEvent } from "../types/events/quickstart-completed.j
 export default class Quickstart extends Command {
   static description = "Get started with your first SDK or API Portal in four easy steps.";
 
-  static summary = "Create your first SDK or API Portal using APIMatic.";
+  static summary = "Create your first Context Plugins, API Portal or SDK using APIMatic.";
 
   static cmdTxt = format.cmd("apimatic", "quickstart");
 

--- a/src/commands/quickstart.ts
+++ b/src/commands/quickstart.ts
@@ -10,7 +10,7 @@ import { QuickstartCompletedEvent } from "../types/events/quickstart-completed.j
 export default class Quickstart extends Command {
   static description = "Get started with your first SDK or API Portal in four easy steps.";
 
-  static summary = "Create your first API Portal with Context Plugins and SDKs, or a standalone SDK, using APIMatic.";
+  static summary = "Create your first API Portal, Context Plugins and SDKs, or a standalone SDK, using APIMatic.";
 
   static cmdTxt = format.cmd("apimatic", "quickstart");
 

--- a/src/prompts/portal/generate.ts
+++ b/src/prompts/portal/generate.ts
@@ -39,7 +39,7 @@ export class PortalGeneratePrompts {
 
   public generatePortal(fn: Promise<Result<NodeJS.ReadableStream, ServiceError | NodeJS.ReadableStream>>) {
     return withSpinner(
-      "Generating API Portal, Context Plugins, and SDKs...",
+      "Generating API Portal",
       "Portal generated successfully.",
       "Portal Generation failed.",
       fn

--- a/src/prompts/portal/generate.ts
+++ b/src/prompts/portal/generate.ts
@@ -38,7 +38,12 @@ export class PortalGeneratePrompts {
   }
 
   public generatePortal(fn: Promise<Result<NodeJS.ReadableStream, ServiceError | NodeJS.ReadableStream>>) {
-    return withSpinner("Generating portal", "Portal generated successfully.", "Portal Generation failed.", fn);
+    return withSpinner(
+      "Generating API Portal, Context Plugins, and SDKs...",
+      "Portal generated successfully.",
+      "Portal Generation failed.",
+      fn
+    );
   }
 
   public portalGenerationError(error: string) {

--- a/src/prompts/portal/quickstart.ts
+++ b/src/prompts/portal/quickstart.ts
@@ -136,7 +136,7 @@ export class PortalQuickstartPrompts {
 
     const languages = (await multiselect({
       message:
-        "Your API Portal will contain SDKs and SDK Documentation in the following Languages (HTTP is enabled by default). Press enter to continue with all languages, or use the arrow keys and space to customize your selection:",
+        "Your API Portal will contain Context Plugins for AI agents, SDKs, and SDK documentation in the following languages (HTTP is enabled by default). Press Enter to continue with all languages, or use the arrow keys and Space to customize your selection",
       options: available.map(({ label, value }) => ({ label, value })),
       initialValues: available.map(({ value }) => value),
       required: false
@@ -256,8 +256,15 @@ export class PortalQuickstartPrompts {
     );
   }
 
-  public nextSteps(): void {
-    const message = `Use the API Playground or an SDK to call your API.
+  public nextSteps(hasAiIntegration: boolean): void {
+    const message = hasAiIntegration
+      ? `Nice work! Your API Portal is ready.
+
+Install your API's Context Plugins to help AI coding agents understand your API and generate more accurate code.
+
+You can also customize the Portal theme, add API recipes and enable AI features.
+${f.link(referenceDocumentationUrl)}`
+      : `Use the API Playground or an SDK to call your API.
 Customize the Portal theme, add API recipes and enable AI features
 ${f.link(referenceDocumentationUrl)}`;
     noteWrapped(message, "Next Steps");

--- a/src/prompts/portal/quickstart.ts
+++ b/src/prompts/portal/quickstart.ts
@@ -136,7 +136,7 @@ export class PortalQuickstartPrompts {
 
     const languages = (await multiselect({
       message:
-        "Your API Portal will contain Context Plugins for AI agents, SDKs, and SDK documentation in the following languages (HTTP is enabled by default). Press Enter to continue with all languages, or use the arrow keys and Space to customize your selection",
+        "Your API Portal can contain Context Plugins for AI agents, SDKs, and SDK documentation in the following languages (HTTP is enabled by default). Press Enter to continue with all languages, or use the arrow keys and Space to customize your selection",
       options: available.map(({ label, value }) => ({ label, value })),
       initialValues: available.map(({ value }) => value),
       required: false
@@ -187,7 +187,7 @@ export class PortalQuickstartPrompts {
       removed.push("API Copilot");
     }
     if (report.removedAiIntegration) {
-      removed.push("AI context plugins (Cursor / VS Code / Claude Code)");
+      removed.push("Context plugins (Cursor / VS Code / Claude Code)");
     }
     if (removed.length === 0) {
       return;
@@ -258,11 +258,11 @@ export class PortalQuickstartPrompts {
 
   public nextSteps(hasAiIntegration: boolean): void {
     const message = hasAiIntegration
-      ? `Nice work! Your API Portal is ready.
+      ? `Your API Portal is ready with Context Plugins enabled.
 
-Install your API's Context Plugins to help AI coding agents understand your API and generate more accurate code.
+Install your API's Context Plugins in Cursor, VS Code, or Claude Code to help AI coding agents understand your API and generate more accurate code.
 
-You can also customize the Portal theme, add API recipes and enable AI features.
+Explore customization options, including Portal themes and API Recipes.
 ${f.link(referenceDocumentationUrl)}`
       : `Use the API Playground or an SDK to call your API.
 Customize the Portal theme, add API recipes and enable AI features
@@ -299,7 +299,7 @@ ${f.link(referenceDocumentationUrl)}`;
   public copilotEnabled(key: string) {
     const message =
       `API Copilot is enabled with key ${f.var(key)}. ` +
-      `Any existing AI context associated with this key will be overwritten when the portal is generated.`;
+      `Any existing Copilot context associated with this key will be overwritten when the portal is generated.`;
     log.warn(message);
   }
 

--- a/src/prompts/quickstart.ts
+++ b/src/prompts/quickstart.ts
@@ -5,16 +5,16 @@ export type QuickstartFlow = "sdk" | "portal" | undefined;
 export class QuickstartPrompts {
   public welcomeMessage() {
     log.info(`Welcome to the APIMatic quickstart wizard.`);
-    log.message(`This wizard will guide you through creating your first SDK or API Documentation Portal in just four easy steps.
+    log.message(`This wizard will guide you through creating your first Context Plugins, API Documentation Portal or SDK in just four easy steps.
 Let's get started!`);
   }
 
   public async selectQuickstartFlow(): Promise<QuickstartFlow> {
     const option = await select({
-      message: "What would you like to create?",
+      message: "How do you want to get started?",
       options: [
-        { value: "portal", label: "API Documentation Portal", hint: "Generate API docs + SDKs" },
-        { value: "sdk", label: "SDK" }
+        { value: "portal", label: "API Portal + Context Plugins + SDKs", hint: "" },
+        { value: "sdk", label: "SDK Only", hint: "Add the API Portal and Context Plugins later" }
       ]
     });
 

--- a/src/prompts/quickstart.ts
+++ b/src/prompts/quickstart.ts
@@ -5,7 +5,7 @@ export type QuickstartFlow = "sdk" | "portal" | undefined;
 export class QuickstartPrompts {
   public welcomeMessage() {
     log.info(`Welcome to the APIMatic quickstart wizard.`);
-    log.message(`This wizard will guide you through creating your first Context Plugins, API Documentation Portal or SDK in just four easy steps.
+    log.message(`This wizard will guide you through creating your first API Documentation Portal with Context Plugins, or SDK in just four easy steps.
 Let's get started!`);
   }
 
@@ -13,7 +13,7 @@ Let's get started!`);
     const option = await select({
       message: "How do you want to get started?",
       options: [
-        { value: "portal", label: "API Portal + Context Plugins + SDKs", hint: "" },
+        { value: "portal", label: "API Documentation Portal", hint: "API Docs + Context Plugins + SDKs" },
         { value: "sdk", label: "SDK Only", hint: "Add the API Portal and Context Plugins later" }
       ]
     });

--- a/src/prompts/quickstart.ts
+++ b/src/prompts/quickstart.ts
@@ -5,7 +5,7 @@ export type QuickstartFlow = "sdk" | "portal" | undefined;
 export class QuickstartPrompts {
   public welcomeMessage() {
     log.info(`Welcome to the APIMatic quickstart wizard.`);
-    log.message(`This wizard will guide you through creating your first API Documentation Portal with Context Plugins, or SDK in just four easy steps.
+    log.message(`This wizard will guide you through creating your first Context Plugins, API Documentation Portal or SDK in just four easy steps.
 Let's get started!`);
   }
 
@@ -13,7 +13,7 @@ Let's get started!`);
     const option = await select({
       message: "How do you want to get started?",
       options: [
-        { value: "portal", label: "API Documentation Portal", hint: "API Docs + Context Plugins + SDKs" },
+        { value: "portal", label: "API Portal + Context Plugins + SDKs", hint: "" },
         { value: "sdk", label: "SDK Only", hint: "Add the API Portal and Context Plugins later" }
       ]
     });

--- a/src/prompts/sdk/quickstart.ts
+++ b/src/prompts/sdk/quickstart.ts
@@ -252,6 +252,8 @@ export class SdkQuickstartPrompts {
 '${f.cmdAlt("apimatic", "sdk", "generate")} ${inputDirectoryFlag}${f.flag("language", language)}'
 to regenerate your SDK.
 
+Explore API Portals and Context Plugins next to enhance your API experience.
+
 To learn more about customizing your SDK, visit:
 ${f.link(sdkCustomizationUrl)}`;
     noteWrapped(message, "Next Steps");

--- a/src/types/build/build.ts
+++ b/src/types/build/build.ts
@@ -198,6 +198,20 @@ export class BuildConfig {
     return this.data.apiCopilotConfig != null;
   }
 
+  // True when at least one language has an AI editor integration (Context Plugin)
+  // enabled in the portal settings. AI integration cannot exist without Copilot, but
+  // Copilot can be present with AI integration disabled — so this is a distinct check.
+  public hasAiIntegration(): boolean {
+    const languageSettings = this.data.generatePortal?.portalSettings?.languageSettings;
+    if (!languageSettings) {
+      return false;
+    }
+    return Object.values(languageSettings).some((setting) => {
+      const ai = setting.aiIntegration;
+      return ai != null && [ai.cursor, ai.claudeCode, ai.vscode].some((editor) => editor?.isEnabled === true);
+    });
+  }
+
   /** Returns a copy with the portal's languageConfig set from the selected friendly language ids. */
   public withPortalLanguages(languages: string[]): BuildConfig {
     const portal = this.data.generatePortal!;


### PR DESCRIPTION
**AI-first messaging + Copilot-aware Portal quickstart Next Steps**

**Summary**

Reworks user-facing copy across quickstart, portal generate, and the SDK quickstart flow to lead with Context Plugins / AI Assist, and makes the Portal quickstart Next Steps adapt to whether AI integration is actually enabled on the subscription. The single behavioural change is that Next Steps message; everything else is copy-only. .vscode/launch.json is intentionally excluded.

**Command-by-command: before → after**

**apimatic quickstart — summary**
- Before: Create your first SDK or API Portal using APIMatic.
- After: Create your first Context Plugins, API Portal or SDK using APIMatic.

**apimatic quickstart — welcome**
- Before: …creating your first SDK or API Documentation Portal in just four easy steps.
- After: …creating your first Context Plugins, API Documentation Portal or SDK in just four easy steps.

**apimatic quickstart — flow selector**
- Before: prompt What would you like to create?; API Documentation Portal (hint Generate API docs + SDKs); SDK
- After: prompt How do you want to get started?; API Portal + Context Plugins + SDKs (no hint); SDK Only (hint Add the API Portal and Context Plugins later)

**apimatic quickstart (Portal) — language selection**
- Before: Your API Portal will contain SDKs and SDK Documentation in the following Languages (HTTP is enabled by default). Press enter … space to customize your selection:
- After: Your API Portal will contain Context Plugins for AI agents, SDKs, and SDK documentation in the following languages (HTTP is enabled by default). Press Enter … Space to customize your selection

**apimatic quickstart (Portal) — Next Steps**
- Before (single): Use the API Playground or an SDK to call your API. / Customize the Portal theme, add API recipes and enable AI features
- After, AI integration ENABLED: Nice work! Your API Portal is ready. … Install your API's Context Plugins to help AI coding agents understand your API and generate more accurate code. … You can also customize the Portal theme, add API recipes and enable AI features.
- After, AI integration DISABLED: unchanged from the previous message.

**apimatic portal generate — summary**
- Before: Generate an API Documentation portal
- After: Generate Context Plugins, API Documentation Portal with AI Assist Features.

**apimatic portal generate — spinner**
- Before: Generating portal
- After: Generating API Portal, Context Plugins, and SDKs...

**apimatic quickstart (SDK) — Next Steps — added line:** Explore API Portals and Context Plugins next to enhance your API experience.

**apimatic sdk generate** — unchanged (avoids the double-print, since quickstart reuses this action).

README.md — regenerated to reflect the two updated summaries.

**Subscription / entitlement logic**

Copilot and Context Plugin (AI integration) are independent features: AI integration can't exist without Copilot, but Copilot can exist with AI integration off — so a Copilot check alone is insufficient. SubscriptionInfo (/account/profile) only exposes ApiCopilotKeys and has no Context Plugin field, so the variant is gated on the pruned build file (the plan-prune is the entitlement authority) via a new BuildConfig.hasAiIntegration():

public hasAiIntegration(): boolean {
  const languageSettings = this.data.generatePortal?.portalSettings?.languageSettings;
  if (!languageSettings) { return false; }
  return Object.values(languageSettings).some((setting) => {
    const ai = setting.aiIntegration;
    return ai != null && [ai.cursor, ai.claudeCode, ai.vscode].some((editor) => editor?.isEnabled === true);
  });
}

Passed into the prompt where the pruned config is already in scope (no extra API call): this.prompts.nextSteps(prunedConfig.hasAiIntegration()). Validated against real prune responses — when AI integration isn't on the plan the server drops the aiIntegration key entirely (removedAiIntegration: true) and the accessor returns false; with it on, true.

**Complexity / Sonar**

hasAiIntegration() is a small new method (well under 15); nextSteps() gained one ternary; no new branches were added to the large execute() method.