### PR TITLE
fix: surface actionable auth hint on validate, transform and publishing commands

### DIFF
--- a/src/actions/auth/status.ts
+++ b/src/actions/auth/status.ts
@@ -13,7 +13,11 @@ export class StatusAction {
 
   public async execute(authKey: string | null): Promise<ActionResult> {
     const accountInfo = await getAuthInfo(this.configDir.toString());
-    if (accountInfo === null) {
+    // `auth logout` blanks config.json rather than deleting it, so a logged-out user still
+    // has a non-null AuthInfo with an empty key. Checking the key catches both that and a
+    // missing config file, and avoids a request that can only come back 401.
+    if (!accountInfo?.authKey) {
+      this.prompts.notLoggedIn();
       return ActionResult.failed();
     }
     const result = await this.prompts.accountInfoSpinner(

--- a/src/infrastructure/services/publishing-api-service.ts
+++ b/src/infrastructure/services/publishing-api-service.ts
@@ -24,8 +24,10 @@ export class PublishingApiService {
     shell: string
   ): Promise<Result<PublishingProfileItem[], ServiceError>> {
     const authInfo: AuthInfo | null = await getAuthInfo(configDir.toString());
-    if (authInfo === null) {
-      return err(ServiceError.UnAuthorized);
+    // `auth logout` blanks config.json rather than deleting it, so a logged-out user
+    // still has a non-null AuthInfo with an empty key — check the key, not the object.
+    if (!authInfo?.authKey) {
+      return err(ServiceError.unauthorizedWithHint(null));
     }
 
     try {
@@ -51,8 +53,10 @@ export class PublishingApiService {
     shell: string
   ): Promise<Result<PublishingInfo, ServiceError>> {
     const authInfo: AuthInfo | null = await getAuthInfo(configDir.toString());
-    if (authInfo === null) {
-      return err(ServiceError.UnAuthorized);
+    // `auth logout` blanks config.json rather than deleting it, so a logged-out user
+    // still has a non-null AuthInfo with an empty key — check the key, not the object.
+    if (!authInfo?.authKey) {
+      return err(ServiceError.unauthorizedWithHint(null));
     }
     const sdkFileStream = await this.fileService.getStream(sdkFilePath);
 
@@ -107,8 +111,10 @@ export class PublishingApiService {
     shell: string
   ): Promise<Result<PublishLogItem, ServiceError>> {
     const authInfo: AuthInfo | null = await getAuthInfo(configDir.toString());
-    if (authInfo === null) {
-      return err(ServiceError.UnAuthorized);
+    // `auth logout` blanks config.json rather than deleting it, so a logged-out user
+    // still has a non-null AuthInfo with an empty key — check the key, not the object.
+    if (!authInfo?.authKey) {
+      return err(ServiceError.unauthorizedWithHint(null));
     }
 
     try {

--- a/src/infrastructure/services/transformation-service.ts
+++ b/src/infrastructure/services/transformation-service.ts
@@ -17,6 +17,7 @@ import { apiClientFactory } from "./api-client-factory.js";
 import { FilePath } from "../../types/file/filePath.js";
 import { CommandMetadata } from "../../types/common/command-metadata.js";
 import { err, ok, Result} from "neverthrow";
+import { ServiceError } from "../service-error.js";
 
 export interface TransformViaFileParams {
   file: FilePath;
@@ -86,7 +87,7 @@ export class TransformationService {
         return "Your API Definition is invalid. Please use the APIMatic VS Code Extension to fix the errors and try again.";
       } else if (apiError.statusCode === 401) {
         const message = JSON.parse(apiError.body as string).message;
-        return `${message} You are not authorized to perform this action. Please run 'auth:login' or provide a valid auth key.`;
+        return ServiceError.unauthorizedWithHint(message).errorMessage;
       }
       return `Error ${apiError.statusCode}: An error occurred during the transformation. Please try again or contact support@apimatic.io for assistance.`;
     } else {

--- a/src/infrastructure/services/validation-service.ts
+++ b/src/infrastructure/services/validation-service.ts
@@ -247,7 +247,7 @@ export class ValidationService {
         case 400:
           return "Your API Definition is invalid. Please fix the issues and try again.";
         case 401:
-          return "You are not authorized to perform this action. Please run 'auth:login' or provide a valid auth key.";
+          return ServiceError.unauthorizedWithHint(null).errorMessage;
         case 403:
           return "You do not have permission to perform this action.";
         case 500:

--- a/src/prompts/auth/status.ts
+++ b/src/prompts/auth/status.ts
@@ -16,11 +16,16 @@ export class StatusPrompts {
     );
   }
 
+  public notLoggedIn() {
+    log.error(`You are not logged in. Please run ${format.cmdAlt("apimatic", "auth", "login")} to log in.`);
+  }
+
   public invalidKeyProvided(serviceError: ServiceError) {
     const message =
       serviceError === ServiceError.UnAuthorized ? "Invalid API key provided." : serviceError.errorMessage;
     log.error(message);
   }
+
 
   public showAccountInfo(info: SubscriptionInfo) {
     const languages = mapLanguages(info.allowedLanguages);


### PR DESCRIPTION
## Fix misleading auth error messages across CLI commands

This PR fixes gaps in Gap#2 found by QA and reported here https://github.com/apimatic/apimatic-io/issues/2180
Note: These are not regression errors from previous changes on this branch, instead new issues identified 

Four commands reported unauthenticated and invalid-credential states with stale,
duplicated, bare, or outright wrong messages. None of them reached the
`ServiceError.unauthorizedWithHint` factory introduced earlier on this branch.

| Command | Before | After |
|---|---|---|
| `api validate` | `…Please run 'auth:login' or provide a valid auth key.` | `You are not authorized to perform this action. Please run apimatic auth login to log in, or provide a valid auth key using the --auth-key flag.` |
| `api transform` | API reason **+** the same legacy string appended (doubled message) | `Authorization has been denied for this request. Please run apimatic auth login to log in, or provide a valid auth key using the --auth-key flag.` |
| `publishing profile list`, `sdk publish` | `Unauthorized access.` | same hint as `api validate` |
| `auth status` (logged out) | `Invalid API key provided.` | `You are not logged in. Please run apimatic auth login to log in.` |
| `auth status` (no config file) | *nothing — silent `Failed`* | same message as above |
| `auth status` (stored key rejected) | `Invalid API key provided.` | unchanged — now the only case that reaches it |

Two commits: the service-layer messages, then `auth status`.

### The blank-config bug behind most of this

`removeAuthInfo` (`auth logout`) **blanks** `config.json` instead of deleting it:

```ts
const credentials: AuthInfo = { email: "", authKey: "" };
```

So getAuthInfo returns a non-null AuthInfo with an empty key, and every
authInfo === null guard in the codebase silently fails to fire for a logged-out
user. Those call sites sent a request with an empty X-Auth-Key purely to
receive a 401, then rendered whatever that 401 mapped to.

That is why publishing profile list showed the bare singleton message, and why
auth status claimed an invalid key had been "provided" to a command that
accepts no auth-key flag. Guards now test the key, not the object:

-if (authInfo === null) {
+if (!authInfo?.authKey) {

Besides fixing the message, this removes a pointless network round-trip from
every logged-out invocation (auth status drops from ~1.5s to ~1s).

**auth status specifics**

**Two separate defects, one condition:**

- Logged out (blank config.json): fell through the guard, got a wire 401,
and printed the login flow's "invalid key" copy. Nothing was provided — and
StatusAction.execute(authKey) is always called with null from
commands/auth/status.ts, so a provided key is impossible here.
- Never logged in (no config.json): the guard did fire, but returned
ActionResult.failed() without printing anything — a bare Failed with no
explanation.

With the guard fixed, both print the actionable "not logged in" message, and
Invalid API key provided. is now reachable only where it's accurate: a
non-empty stored key that the API rejects as expired or revoked. Verified in all
three states, including with a planted invalid key.

**Service-layer message fixes**

- validation-service and transformation-service each keep a private
message catalog and never call the shared mapper, so both carried the legacy
'auth:login' text — a command syntax this CLI doesn't have. transform
additionally concatenated it on top of the API's own 401 reason, producing a
visibly doubled message.
- Only the 401 branches were redirected to the shared factory. Existing
400/403/500 text in both catalogs is untouched, so no non-auth message changes.
- All three publishing pre-checks were fixed, not just the reported
profile list one — they share the identical condition, and fixing one would
leave sdk publish printing the bare string.

**Decisions**

- handleServiceError's axios-401 branch was not touched.
prompts/auth/status.ts identity-compares against the
ServiceError.UnAuthorized singleton to select its invalid-key message;
unauthorizedWithHint returns a fresh instance, so changing that branch would
silently break it. 

**Known gap:**

Below Gap is reported by QA as Gap#3 in the Test report added earlier in the message.
This will be handled in a seperate issue here https://github.com/apimatic/apimatic-cli/issues/301. This is a Bug.

1. portal toc new when unauthenticated — separate issue. It swallows the
401 into "falling back to the default TOC structure", overwrites a real
toc.yml with an empty-component one, returns exit 0, and then hangs
indefinitely: generateTocData is a stream-response endpoint, so the SDK
returns ApiError.body as an undrained IncomingMessage, the TLS socket stays
open, and outro() only sets process.exitCode rather than calling
process.exit. Confirmed via handle probe (TLSSocket … readable=true);
destroying that stream turns a 90s hang into a 3s exit. Latent in any
stream-endpoint error, including the portal/SDK downloads.
