### PR TITLE
fix: surface TOC extraction failures instead of writing a partial toc…

### DIFF
--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -62,13 +62,16 @@ export class PortalNewTocAction {
     // Missing and empty are reported separately: `SpecContext.validate()` treats
     // both as invalid, but only one of them is fixed by adding files to a
     // directory that already exists.
+    // Both messages report the build directory rather than the `spec/` path
+    // inside it: that is the directory the user works in, and it is what the
+    // sibling messages here and in `sdk generate` already name.
     const specDirectory = buildDirectory.join('spec');
     if (!(await this.fileService.directoryExists(specDirectory))) {
-      this.prompts.specDirectoryNotFound(specDirectory);
+      this.prompts.specDirectoryNotFound(buildDirectory);
       return ActionResult.failed();
     }
     if (!(await new SpecContext(specDirectory).validate())) {
-      this.prompts.specDirectoryEmpty(specDirectory);
+      this.prompts.specDirectoryEmpty(buildDirectory);
       return ActionResult.failed();
     }
 

--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -13,7 +13,6 @@ import {
 import { withDirPath } from '../../../infrastructure/tmp-extensions.js';
 import { TempContext } from '../../../types/temp-context.js';
 import { PortalService } from '../../../infrastructure/services/portal-service.js';
-import { SpecContext } from '../../../types/spec-context.js';
 import { err, ok, Result } from 'neverthrow';
 import { ServiceError } from '../../../infrastructure/service-error.js';
 
@@ -56,21 +55,12 @@ export class PortalNewTocAction {
       return ActionResult.failed();
     }
 
-    // The spec is required, not optional: it is what the TOC is built from, and
-    // the next step — portal generation — needs it regardless. Writing a TOC
-    // without it only defers the failure to a later command, so fail here.
-    // Missing and empty are reported separately: `SpecContext.validate()` treats
-    // both as invalid, but only one of them is fixed by adding files to a
-    // directory that already exists.
-    // Both messages report the build directory rather than the `spec/` path
-    // inside it: that is the directory the user works in, and it is what the
-    // sibling messages here and in `sdk generate` already name.
     const specDirectory = buildDirectory.join('spec');
     if (!(await this.fileService.directoryExists(specDirectory))) {
       this.prompts.specDirectoryNotFound(buildDirectory);
       return ActionResult.failed();
     }
-    if (!(await new SpecContext(specDirectory).validate())) {
+    if (!(await buildContext.getSpecContext().validate())) {
       this.prompts.specDirectoryEmpty(buildDirectory);
       return ActionResult.failed();
     }
@@ -108,10 +98,6 @@ export class PortalNewTocAction {
       }
     });
 
-    // This used to fall back to the default TOC, which wrote a file missing its
-    // Endpoints, Events and Models sections over a possibly valid toc.yml and
-    // reported success. Surface the reason (auth, network, invalid spec) and
-    // leave the file alone.
     if (tocComponentsResult.isErr()) {
       this.prompts.tocExtractionFailed(tocComponentsResult.error.errorMessage);
       return ActionResult.failed();

--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -13,6 +13,7 @@ import {
 import { withDirPath } from '../../../infrastructure/tmp-extensions.js';
 import { TempContext } from '../../../types/temp-context.js';
 import { PortalService } from '../../../infrastructure/services/portal-service.js';
+import { SpecContext } from '../../../types/spec-context.js';
 import { err, ok, Result } from 'neverthrow';
 import { ServiceError } from '../../../infrastructure/service-error.js';
 
@@ -55,23 +56,19 @@ export class PortalNewTocAction {
       return ActionResult.failed();
     }
 
-    // The `--expand-*` flags enumerate endpoints, models and events in the TOC,
-    // which only the spec can supply. Without one the generator falls back to the
-    // collapsed `generate:` directives and the flags are dropped, so honour the
-    // documented requirement instead of reporting success for a TOC the user did
-    // not ask for. Checked before the overwrite prompt below so a run that cannot
-    // succeed asks nothing first.
+    // The spec is required, not optional: it is what the TOC is built from, and
+    // the next step — portal generation — needs it regardless. Writing a TOC
+    // without it only defers the failure to a later command, so fail here.
+    // Missing and empty are reported separately: `SpecContext.validate()` treats
+    // both as invalid, but only one of them is fixed by adding files to a
+    // directory that already exists.
     const specDirectory = buildDirectory.join('spec');
-    const specExists = await this.fileService.directoryExists(specDirectory);
-    const requestedExpansions = [
-      expandEndpoints && 'expand-endpoints',
-      expandModels && 'expand-models',
-      expandWebhooks && 'expand-webhooks',
-      expandCallbacks && 'expand-callbacks'
-    ].filter((flag): flag is string => typeof flag === 'string');
-
-    if (!specExists && requestedExpansions.length > 0) {
-      this.prompts.expandFlagsRequireSpec(requestedExpansions, specDirectory);
+    if (!(await this.fileService.directoryExists(specDirectory))) {
+      this.prompts.specDirectoryNotFound(specDirectory);
+      return ActionResult.failed();
+    }
+    if (!(await new SpecContext(specDirectory).validate())) {
+      this.prompts.specDirectoryEmpty(specDirectory);
       return ActionResult.failed();
     }
 
@@ -86,41 +83,32 @@ export class PortalNewTocAction {
       return ActionResult.cancelled();
     }
 
-    const tocComponentsResult: Result<TocComponents, ServiceError> = await (async () => {
-      // No spec to extract from is an expected case, not a failure: the default
-      // TOC is the correct output. A failed extraction is not — see below. Any
-      // `--expand-*` flag combined with a missing spec already failed above.
-      if (!specExists) {
-        this.prompts.fallingBackToDefault();
-        return ok(TocComponents.empty());
-      }
-
-      return await withDirPath(async (tempDirectory) => {
-        const tempContext = new TempContext(tempDirectory);
-        const specZipPath = await tempContext.zip(specDirectory);
-        const specFileStream = await this.fileService.getStream(specZipPath);
-        try {
-          const result = await this.prompts.extractTocData(
-            this.portalService.generateTocData(specFileStream, this.configDirectory, this.commandMetadata),
-            expandEndpoints,
-            expandModels,
-            expandWebhooks,
-            expandCallbacks
-          );
-          if (result.isErr()) {
-            return err(result.error);
-          }
-
-          return ok(TocComponents.fromTocData(result.value));
-        } finally {
-          specFileStream.close();
+    const tocComponentsResult: Result<TocComponents, ServiceError> = await withDirPath(async (tempDirectory) => {
+      const tempContext = new TempContext(tempDirectory);
+      const specZipPath = await tempContext.zip(specDirectory);
+      const specFileStream = await this.fileService.getStream(specZipPath);
+      try {
+        const result = await this.prompts.extractTocData(
+          this.portalService.generateTocData(specFileStream, this.configDirectory, this.commandMetadata),
+          expandEndpoints,
+          expandModels,
+          expandWebhooks,
+          expandCallbacks
+        );
+        if (result.isErr()) {
+          return err(result.error);
         }
-      });
-    })();
 
-    // Falling back here would write a TOC missing its Endpoints, Events and
-    // Models sections over a possibly valid toc.yml, and report success. Surface
-    // the reason (auth, network, invalid spec) and leave the file alone.
+        return ok(TocComponents.fromTocData(result.value));
+      } finally {
+        specFileStream.close();
+      }
+    });
+
+    // This used to fall back to the default TOC, which wrote a file missing its
+    // Endpoints, Events and Models sections over a possibly valid toc.yml and
+    // reported success. Surface the reason (auth, network, invalid spec) and
+    // leave the file alone.
     if (tocComponentsResult.isErr()) {
       this.prompts.tocExtractionFailed(tocComponentsResult.error.errorMessage);
       return ActionResult.failed();

--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -54,6 +54,27 @@ export class PortalNewTocAction {
       this.prompts.invalidBuildDirectory(buildDirectory);
       return ActionResult.failed();
     }
+
+    // The `--expand-*` flags enumerate endpoints, models and events in the TOC,
+    // which only the spec can supply. Without one the generator falls back to the
+    // collapsed `generate:` directives and the flags are dropped, so honour the
+    // documented requirement instead of reporting success for a TOC the user did
+    // not ask for. Checked before the overwrite prompt below so a run that cannot
+    // succeed asks nothing first.
+    const specDirectory = buildDirectory.join('spec');
+    const specExists = await this.fileService.directoryExists(specDirectory);
+    const requestedExpansions = [
+      expandEndpoints && 'expand-endpoints',
+      expandModels && 'expand-models',
+      expandWebhooks && 'expand-webhooks',
+      expandCallbacks && 'expand-callbacks'
+    ].filter((flag): flag is string => typeof flag === 'string');
+
+    if (!specExists && requestedExpansions.length > 0) {
+      this.prompts.expandFlagsRequireSpec(requestedExpansions, specDirectory);
+      return ActionResult.failed();
+    }
+
     const buildConfig = await buildContext.getBuildFileContents();
     const contentDirectory = buildDirectory.join(buildConfig.contentFolder());
 
@@ -66,11 +87,10 @@ export class PortalNewTocAction {
     }
 
     const tocComponentsResult: Result<TocComponents, ServiceError> = await (async () => {
-      const specDirectory = buildDirectory.join('spec');
-
       // No spec to extract from is an expected case, not a failure: the default
-      // TOC is the correct output. A failed extraction is not — see below.
-      if (!(await this.fileService.directoryExists(specDirectory))) {
+      // TOC is the correct output. A failed extraction is not — see below. Any
+      // `--expand-*` flag combined with a missing spec already failed above.
+      if (!specExists) {
         this.prompts.fallingBackToDefault();
         return ok(TocComponents.empty());
       }

--- a/src/actions/portal/toc/new-toc.ts
+++ b/src/actions/portal/toc/new-toc.ts
@@ -13,6 +13,8 @@ import {
 import { withDirPath } from '../../../infrastructure/tmp-extensions.js';
 import { TempContext } from '../../../types/temp-context.js';
 import { PortalService } from '../../../infrastructure/services/portal-service.js';
+import { err, ok, Result } from 'neverthrow';
+import { ServiceError } from '../../../infrastructure/service-error.js';
 
 export class ContentContext {
   private readonly fileService = new FileService();
@@ -63,34 +65,48 @@ export class PortalNewTocAction {
       return ActionResult.cancelled();
     }
 
-    const tocComponents: TocComponents = await (async () => {
+    const tocComponentsResult: Result<TocComponents, ServiceError> = await (async () => {
       const specDirectory = buildDirectory.join('spec');
 
+      // No spec to extract from is an expected case, not a failure: the default
+      // TOC is the correct output. A failed extraction is not — see below.
       if (!(await this.fileService.directoryExists(specDirectory))) {
         this.prompts.fallingBackToDefault();
-        return TocComponents.empty();
+        return ok(TocComponents.empty());
       }
 
       return await withDirPath(async (tempDirectory) => {
         const tempContext = new TempContext(tempDirectory);
         const specZipPath = await tempContext.zip(specDirectory);
         const specFileStream = await this.fileService.getStream(specZipPath);
-        const result = await this.prompts.extractTocData(
-          this.portalService.generateTocData(specFileStream, this.configDirectory, this.commandMetadata),
-          expandEndpoints,
-          expandModels,
-          expandWebhooks,
-          expandCallbacks
-        );
-        specFileStream.close();
-        if (result.isErr()) {
-          this.prompts.fallingBackToDefault();
-          return TocComponents.empty();
-        }
+        try {
+          const result = await this.prompts.extractTocData(
+            this.portalService.generateTocData(specFileStream, this.configDirectory, this.commandMetadata),
+            expandEndpoints,
+            expandModels,
+            expandWebhooks,
+            expandCallbacks
+          );
+          if (result.isErr()) {
+            return err(result.error);
+          }
 
-        return TocComponents.fromTocData(result.value);
+          return ok(TocComponents.fromTocData(result.value));
+        } finally {
+          specFileStream.close();
+        }
       });
     })();
+
+    // Falling back here would write a TOC missing its Endpoints, Events and
+    // Models sections over a possibly valid toc.yml, and report success. Surface
+    // the reason (auth, network, invalid spec) and leave the file alone.
+    if (tocComponentsResult.isErr()) {
+      this.prompts.tocExtractionFailed(tocComponentsResult.error.errorMessage);
+      return ActionResult.failed();
+    }
+    const tocComponents = tocComponentsResult.value;
+
     const contentContext = new ContentContext(contentDirectory);
     const contentExists = await contentContext.exists();
 

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -96,8 +96,29 @@ function mapApiError(error: ApiError): ServiceError {
   return ServiceError.ServerError;
 }
 
+// Endpoints the SDK issues via `callAsStream` (TOC data, portal/SDK downloads,
+// transformed files) hand back an undrained `IncomingMessage` on `ApiError.body`
+// when they fail. Its socket stays open and keeps the Node event loop alive, so
+// the CLI hangs after printing its outro — `outro()` only sets
+// `process.exitCode` and we never call `process.exit()`. Discard the body once
+// we've decided to map the error to a message.
+//
+// Callers that need the body read it *before* reaching here (see
+// `PortalService.generatePortal`, which returns the 422 body as the error
+// report). Non-stream bodies are strings or Blobs and have no `destroy`.
+export function discardStreamBody(error: ApiError): void {
+  const body = error.body as { destroy?: () => void } | undefined;
+  if (typeof body?.destroy === "function") {
+    body.destroy();
+  }
+}
+
 export function handleServiceError(error: unknown): ServiceError {
-  if (error instanceof ApiError) return mapApiError(error);
+  if (error instanceof ApiError) {
+    const serviceError = mapApiError(error);
+    discardStreamBody(error);
+    return serviceError;
+  }
 
   if (axios.isAxiosError(error)) {
     const status = error.response?.status;

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { ApiError, ProblemDetailsError } from "@apimatic/sdk";
 import { format as f } from "../prompts/format.js";
+import { discardStreamBody } from "../utils/utils.js";
 
 export enum ServiceErrorCode {
   NotFound = "NOT_FOUND",
@@ -96,27 +97,12 @@ function mapApiError(error: ApiError): ServiceError {
   return ServiceError.ServerError;
 }
 
-// Endpoints the SDK issues via `callAsStream` (TOC data, portal/SDK downloads,
-// transformed files) hand back an undrained `IncomingMessage` on `ApiError.body`
-// when they fail. Its socket stays open and keeps the Node event loop alive, so
-// the CLI hangs after printing its outro — `outro()` only sets
-// `process.exitCode` and we never call `process.exit()`. Discard the body once
-// we've decided to map the error to a message.
-//
-// Callers that need the body read it *before* reaching here (see
-// `PortalService.generatePortal`, which returns the 422 body as the error
-// report). Non-stream bodies are strings or Blobs and have no `destroy`.
-export function discardStreamBody(error: ApiError): void {
-  const body = error.body as { destroy?: () => void } | undefined;
-  if (typeof body?.destroy === "function") {
-    body.destroy();
-  }
-}
-
 export function handleServiceError(error: unknown): ServiceError {
   if (error instanceof ApiError) {
+    // Mapped first so it can still read `error.result`, then the body is
+    // released — a `callAsStream` error body would otherwise hang the CLI.
     const serviceError = mapApiError(error);
-    discardStreamBody(error);
+    discardStreamBody(error.body);
     return serviceError;
   }
 

--- a/src/infrastructure/service-error.ts
+++ b/src/infrastructure/service-error.ts
@@ -99,8 +99,10 @@ function mapApiError(error: ApiError): ServiceError {
 
 export function handleServiceError(error: unknown): ServiceError {
   if (error instanceof ApiError) {
-    // Mapped first so it can still read `error.result`, then the body is
-    // released — a `callAsStream` error body would otherwise hang the CLI.
+    // A `callAsStream` error body would otherwise hang the CLI. Order against
+    // `mapApiError` is free: `error.result` is only populated when the SDK
+    // drained the body itself, so a live stream and a readable `result` never
+    // coexist.
     const serviceError = mapApiError(error);
     discardStreamBody(error.body);
     return serviceError;

--- a/src/infrastructure/services/transformation-service.ts
+++ b/src/infrastructure/services/transformation-service.ts
@@ -80,6 +80,23 @@ export class TransformationService {
     };
   };
 
+  /**
+   * A 401 body is not guaranteed to be JSON: a stream endpoint hands back an
+   * `IncomingMessage`, an empty body parses to nothing, and an authenticating
+   * proxy can answer with an HTML error page. Throwing here would escape the
+   * catch in `transformViaFile` — this runs inside the `err(await ...)` it
+   * builds — and surface as an unhandled rejection, skipping the outro and the
+   * failure telemetry. Fall back to the hint's own default message instead.
+   */
+  private parseApiMessage(body: unknown): string | null {
+    if (typeof body !== "string") return null;
+    try {
+      return (JSON.parse(body) as { message?: string })?.message ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private readonly handleTransformationErrors = async (error: unknown): Promise<string> => {
     if (error instanceof ApiError) {
       const apiError = error as ApiError;
@@ -87,8 +104,7 @@ export class TransformationService {
         if (apiError.statusCode === 400) {
           return "Your API Definition is invalid. Please use the APIMatic VS Code Extension to fix the errors and try again.";
         } else if (apiError.statusCode === 401) {
-          const message = JSON.parse(apiError.body as string).message;
-          return ServiceError.unauthorizedWithHint(message).errorMessage;
+          return ServiceError.unauthorizedWithHint(this.parseApiMessage(apiError.body)).errorMessage;
         }
         return `Error ${apiError.statusCode}: An error occurred during the transformation. Please try again or contact support@apimatic.io for assistance.`;
       } finally {

--- a/src/infrastructure/services/transformation-service.ts
+++ b/src/infrastructure/services/transformation-service.ts
@@ -17,7 +17,7 @@ import { apiClientFactory } from "./api-client-factory.js";
 import { FilePath } from "../../types/file/filePath.js";
 import { CommandMetadata } from "../../types/common/command-metadata.js";
 import { err, ok, Result} from "neverthrow";
-import { ServiceError } from "../service-error.js";
+import { discardStreamBody, ServiceError } from "../service-error.js";
 
 export interface TransformViaFileParams {
   file: FilePath;
@@ -83,13 +83,20 @@ export class TransformationService {
   private readonly handleTransformationErrors = async (error: unknown): Promise<string> => {
     if (error instanceof ApiError) {
       const apiError = error as ApiError;
-      if (apiError.statusCode === 400) {
-        return "Your API Definition is invalid. Please use the APIMatic VS Code Extension to fix the errors and try again.";
-      } else if (apiError.statusCode === 401) {
-        const message = JSON.parse(apiError.body as string).message;
-        return ServiceError.unauthorizedWithHint(message).errorMessage;
+      try {
+        if (apiError.statusCode === 400) {
+          return "Your API Definition is invalid. Please use the APIMatic VS Code Extension to fix the errors and try again.";
+        } else if (apiError.statusCode === 401) {
+          const message = JSON.parse(apiError.body as string).message;
+          return ServiceError.unauthorizedWithHint(message).errorMessage;
+        }
+        return `Error ${apiError.statusCode}: An error occurred during the transformation. Please try again or contact support@apimatic.io for assistance.`;
+      } finally {
+        // `downloadTransformedFile` is a stream endpoint: its error body is an
+        // undrained response that would keep the event loop alive. Released
+        // after the message is built, so the 401 branch can still read it.
+        discardStreamBody(apiError);
       }
-      return `Error ${apiError.statusCode}: An error occurred during the transformation. Please try again or contact support@apimatic.io for assistance.`;
     } else {
       return "An unexpected error occurred while validating your API Definition. Please try again later. If the problem persists, please reach out to our team at support@apimatic.io";
     }

--- a/src/infrastructure/services/transformation-service.ts
+++ b/src/infrastructure/services/transformation-service.ts
@@ -17,7 +17,8 @@ import { apiClientFactory } from "./api-client-factory.js";
 import { FilePath } from "../../types/file/filePath.js";
 import { CommandMetadata } from "../../types/common/command-metadata.js";
 import { err, ok, Result} from "neverthrow";
-import { discardStreamBody, ServiceError } from "../service-error.js";
+import { ServiceError } from "../service-error.js";
+import { discardStreamBody } from "../../utils/utils.js";
 
 export interface TransformViaFileParams {
   file: FilePath;
@@ -65,7 +66,7 @@ export class TransformationService {
         apiValidationSummary
       });
     } catch (error) {
-      return err(await this.handleTransformationErrors(error));
+      return err(this.handleTransformationErrors(error));
     }
   }
 
@@ -80,14 +81,6 @@ export class TransformationService {
     };
   };
 
-  /**
-   * A 401 body is not guaranteed to be JSON: a stream endpoint hands back an
-   * `IncomingMessage`, an empty body parses to nothing, and an authenticating
-   * proxy can answer with an HTML error page. Throwing here would escape the
-   * catch in `transformViaFile` — this runs inside the `err(await ...)` it
-   * builds — and surface as an unhandled rejection, skipping the outro and the
-   * failure telemetry. Fall back to the hint's own default message instead.
-   */
   private parseApiMessage(body: unknown): string | null {
     if (typeof body !== "string") return null;
     try {
@@ -97,24 +90,24 @@ export class TransformationService {
     }
   }
 
-  private readonly handleTransformationErrors = async (error: unknown): Promise<string> => {
-    if (error instanceof ApiError) {
-      const apiError = error as ApiError;
-      try {
-        if (apiError.statusCode === 400) {
-          return "Your API Definition is invalid. Please use the APIMatic VS Code Extension to fix the errors and try again.";
-        } else if (apiError.statusCode === 401) {
-          return ServiceError.unauthorizedWithHint(this.parseApiMessage(apiError.body)).errorMessage;
-        }
-        return `Error ${apiError.statusCode}: An error occurred during the transformation. Please try again or contact support@apimatic.io for assistance.`;
-      } finally {
-        // `downloadTransformedFile` is a stream endpoint: its error body is an
-        // undrained response that would keep the event loop alive. Released
-        // after the message is built, so the 401 branch can still read it.
-        discardStreamBody(apiError);
-      }
-    } else {
+  private readonly handleTransformationErrors = (error: unknown): string => {
+    if (!(error instanceof ApiError)) {
       return "An unexpected error occurred while validating your API Definition. Please try again later. If the problem persists, please reach out to our team at support@apimatic.io";
+    }
+
+    // `downloadTransformedFile` is a stream endpoint, so its error body is an
+    // undrained response that would keep the event loop alive. Discarding it
+    // first is safe: a string body (from `transformViaFile`) has no `destroy`
+    // and is left intact for `parseApiMessage` below.
+    discardStreamBody(error.body);
+
+    switch (error.statusCode) {
+      case 400:
+        return "Your API Definition is invalid. Please use the APIMatic VS Code Extension to fix the errors and try again.";
+      case 401:
+        return ServiceError.unauthorizedWithHint(this.parseApiMessage(error.body)).errorMessage;
+      default:
+        return `Error ${error.statusCode}: An error occurred during the transformation. Please try again or contact support@apimatic.io for assistance.`;
     }
   };
 }

--- a/src/infrastructure/services/validation-service.ts
+++ b/src/infrastructure/services/validation-service.ts
@@ -20,7 +20,7 @@ import FormData from "form-data";
 import { ZipService } from "../zip-service.js";
 import { FileService } from "../file-service.js";
 import { withDirPath } from "../tmp-extensions.js";
-import { handleServiceError, ServiceError } from "../service-error.js";
+import { discardStreamBody, handleServiceError, ServiceError } from "../service-error.js";
 import axios from "axios";
 import { envInfo } from "../env-info.js";
 import { Buffer } from "node:buffer";
@@ -242,6 +242,10 @@ export class ValidationService {
   private async handleValidationErrors(error: unknown): Promise<string> {
     if (error instanceof ApiError) {
       const apiError = error as ApiError;
+
+      // A stream-endpoint error body is an undrained response that would keep
+      // the event loop alive and hang the CLI after its outro.
+      discardStreamBody(apiError);
 
       switch (apiError.statusCode) {
         case 400:

--- a/src/infrastructure/services/validation-service.ts
+++ b/src/infrastructure/services/validation-service.ts
@@ -20,7 +20,7 @@ import FormData from "form-data";
 import { ZipService } from "../zip-service.js";
 import { FileService } from "../file-service.js";
 import { withDirPath } from "../tmp-extensions.js";
-import { discardStreamBody, handleServiceError, ServiceError } from "../service-error.js";
+import { handleServiceError, ServiceError } from "../service-error.js";
 import axios from "axios";
 import { envInfo } from "../env-info.js";
 import { Buffer } from "node:buffer";
@@ -242,10 +242,6 @@ export class ValidationService {
   private async handleValidationErrors(error: unknown): Promise<string> {
     if (error instanceof ApiError) {
       const apiError = error as ApiError;
-
-      // A stream-endpoint error body is an undrained response that would keep
-      // the event loop alive and hang the CLI after its outro.
-      discardStreamBody(apiError);
 
       switch (apiError.statusCode) {
         case 400:

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -21,19 +21,16 @@ export class PortalNewTocPrompts {
     return overwrite;
   }
 
-  public fallingBackToDefault() {
-    log.warn(`Falling back to the default TOC structure.`);
+  public specDirectoryNotFound(directory: DirectoryPath) {
+    log.error(
+      `The ${f.var("spec")} directory was not found at ${f.path(directory)}.\n` +
+        `Add your API specification there and try again.`
+    );
   }
 
-  public expandFlagsRequireSpec(flagNames: string[], specDirectory: DirectoryPath) {
-    const flags = flagNames.map((name) => f.flag(name)).join(", ");
-    const plural = flagNames.length > 1;
-    log.error(
-      `${flags} ${plural ? "require" : "requires"} an API specification to expand, ` +
-        `but no spec directory was found at ${f.path(specDirectory)}.\n` +
-        `Add your API specification there, or re-run without ${plural ? "the flags" : "the flag"} ` +
-        `to generate the default TOC.`
-    );
+  public specDirectoryEmpty(directory: DirectoryPath) {
+    const message = `The ${f.var("spec")} directory is either empty or invalid: ${f.path(directory)}`;
+    log.error(message);
   }
 
   public tocFileAlreadyExists() {

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -29,8 +29,7 @@ export class PortalNewTocPrompts {
   }
 
   public specDirectoryEmpty(directory: DirectoryPath) {
-    const message = `The ${f.var("spec")} directory in ${f.path(directory)} is either empty or invalid.`;
-    log.error(message);
+    log.error(`The ${f.var("spec")} directory in ${f.path(directory)} is either empty or invalid.`);
   }
 
   public tocFileAlreadyExists() {

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -25,6 +25,17 @@ export class PortalNewTocPrompts {
     log.warn(`Falling back to the default TOC structure.`);
   }
 
+  public expandFlagsRequireSpec(flagNames: string[], specDirectory: DirectoryPath) {
+    const flags = flagNames.map((name) => f.flag(name)).join(", ");
+    const plural = flagNames.length > 1;
+    log.error(
+      `${flags} ${plural ? "require" : "requires"} an API specification to expand, ` +
+        `but no spec directory was found at ${f.path(specDirectory)}.\n` +
+        `Add your API specification there, or re-run without ${plural ? "the flags" : "the flag"} ` +
+        `to generate the default TOC.`
+    );
+  }
+
   public tocFileAlreadyExists() {
     log.error(`Please enter a different destination path or delete the existing toc.yml file and try again.`);
   }

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -23,7 +23,7 @@ export class PortalNewTocPrompts {
 
   public specDirectoryNotFound(directory: DirectoryPath) {
     log.error(
-      `The ${f.var("spec")} directory was not found at ${f.path(directory)}.\n` +
+      `The ${f.var("spec")} directory was not found in ${f.path(directory)}.\n` +
         `Add your API specification there and try again.`
     );
   }

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -29,7 +29,7 @@ export class PortalNewTocPrompts {
   }
 
   public specDirectoryEmpty(directory: DirectoryPath) {
-    const message = `The ${f.var("spec")} directory is either empty or invalid: ${f.path(directory)}`;
+    const message = `The ${f.var("spec")} directory in ${f.path(directory)} is either empty or invalid.`;
     log.error(message);
   }
 

--- a/src/prompts/portal/toc/new-toc.ts
+++ b/src/prompts/portal/toc/new-toc.ts
@@ -29,7 +29,7 @@ export class PortalNewTocPrompts {
     log.error(`Please enter a different destination path or delete the existing toc.yml file and try again.`);
   }
 
-  public logError(message: string) {
+  public tocExtractionFailed(message: string) {
     log.error(message);
   }
 

--- a/src/types/toc/toc-components.ts
+++ b/src/types/toc/toc-components.ts
@@ -60,10 +60,6 @@ export class TocComponents {
     this.callbackGroups = callbackGroups;
   }
 
-  static empty(): TocComponents {
-    return new TocComponents(new Map(), [], [], [], [], [], new Map(), new Map());
-  }
-
   static fromTocData(tocData: TocData): TocComponents {
     return new TocComponents(
       TocComponents.toEndpointGroups(tocData.endpoints),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -23,7 +23,7 @@ export async function parseStreamBodyToJson(body: NodeJS.ReadableStream): Promis
 // and `IncomingMessage` — so narrowing an `ApiError.body` union still won't let
 // us call it. Probe for the method instead.
 function isDestroyable(value: unknown): value is { destroy: () => void } {
-  return typeof (value as { destroy?: unknown } | undefined)?.destroy === "function";
+  return typeof (value as { destroy?: unknown })?.destroy === "function";
 }
 
 // Counterpart to `parseStreamBodyToJson`: releases a response body we are never

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,6 +19,30 @@ export async function parseStreamBodyToJson(body: NodeJS.ReadableStream): Promis
   return JSON.parse(text);
 }
 
+// `destroy()` is not on `NodeJS.ReadableStream` — it lives on `stream.Readable`
+// and `IncomingMessage` — so narrowing an `ApiError.body` union still won't let
+// us call it. Probe for the method instead.
+function isDestroyable(value: unknown): value is { destroy: () => void } {
+  return typeof (value as { destroy?: unknown } | undefined)?.destroy === "function";
+}
+
+// Counterpart to `parseStreamBodyToJson`: releases a response body we are never
+// going to read. An `ApiError.body` from a `callAsStream` endpoint is an
+// undrained `IncomingMessage` whose socket keeps the Node event loop alive, so
+// the CLI hangs after printing its outro — `outro()` only sets `process.exitCode`
+// and we never call `process.exit()`.
+//
+// The axios adapter yields a stream on Node and a Blob elsewhere, so the probe
+// above is a real platform branch. `destroy()` is idempotent, making this safe
+// on bodies the SDK has already drained via `loadResult`. Callers that need the
+// body must read it *before* calling this (see `PortalService.generatePortal`,
+// which returns the 422 body as the error report).
+export function discardStreamBody(body: unknown): void {
+  if (isDestroyable(body)) {
+    body.destroy();
+  }
+}
+
 export const toPascalCase = (str: string): string => {
   return str
     .split(" ")

--- a/test/actions/portal/toc/new-toc.test.ts
+++ b/test/actions/portal/toc/new-toc.test.ts
@@ -1,0 +1,69 @@
+import * as path from "path";
+import fsExtra from "fs-extra";
+import { expect } from "chai";
+import { dir as tmpDir, DirectoryResult } from "tmp-promise";
+import { PortalNewTocAction } from "../../../../src/actions/portal/toc/new-toc.js";
+import { DirectoryPath } from "../../../../src/types/file/directoryPath.js";
+import { CommandMetadata } from "../../../../src/types/common/command-metadata.js";
+
+const COMMAND_METADATA: CommandMetadata = { commandName: "portal toc new", shell: "test" };
+
+// `portal toc new` used to fall back to the default TOC when it had no spec to
+// extract from — writing a toc.yml with no Endpoints, Events or Models sections
+// over a possibly valid file, and exiting 0. The spec is now required. These
+// cases return before any request is made, so no service stubbing is needed.
+describe("PortalNewTocAction spec directory requirement", () => {
+  let tmpDirResult: DirectoryResult;
+  let buildDirectory: string;
+  let action: PortalNewTocAction;
+
+  const execute = () => action.execute(new DirectoryPath(buildDirectory));
+
+  beforeEach(async () => {
+    tmpDirResult = await tmpDir({ unsafeCleanup: true });
+    buildDirectory = path.join(tmpDirResult.path, "build");
+    await fsExtra.ensureDir(buildDirectory);
+    // `BuildContext.validate()` only checks that the build file exists — the
+    // spec checks run before its contents are ever read.
+    await fsExtra.writeJson(path.join(buildDirectory, "APIMATIC-BUILD.json"), {});
+
+    action = new PortalNewTocAction(new DirectoryPath(tmpDirResult.path), COMMAND_METADATA);
+  });
+
+  afterEach(async () => {
+    await tmpDirResult.cleanup();
+  });
+
+  it("fails when the spec directory is missing", async () => {
+    const result = await execute();
+
+    expect(result.isFailed()).to.be.true;
+  });
+
+  it("fails when the spec directory exists but is empty", async () => {
+    await fsExtra.ensureDir(path.join(buildDirectory, "spec"));
+
+    const result = await execute();
+
+    expect(result.isFailed()).to.be.true;
+  });
+
+  it("fails when the spec directory holds only dotfiles", async () => {
+    // `FileService.directoryEmpty` filters dot-prefixed entries, so a spec
+    // directory kept alive by a .gitkeep still has nothing to extract.
+    const specDirectory = path.join(buildDirectory, "spec");
+    await fsExtra.ensureDir(specDirectory);
+    await fsExtra.writeFile(path.join(specDirectory, ".gitkeep"), "");
+
+    const result = await execute();
+
+    expect(result.isFailed()).to.be.true;
+  });
+
+  it("writes no toc.yml when the spec is missing", async () => {
+    await execute();
+
+    const written = await fsExtra.readdir(buildDirectory);
+    expect(written).to.deep.equal(["APIMATIC-BUILD.json"]);
+  });
+});

--- a/test/utils/utils.test.ts
+++ b/test/utils/utils.test.ts
@@ -1,0 +1,51 @@
+import { Readable } from "stream";
+import { expect } from "chai";
+import { discardStreamBody } from "../../src/utils/utils.js";
+
+// `ApiError.body` is `string | Blob | NodeJS.ReadableStream`, and which one it
+// is depends on the endpoint: `callAsStream` yields a stream on Node, a Blob
+// elsewhere, and `callAsJson` yields a string. `discardStreamBody` has to
+// release the first without disturbing the others, so the probe is the contract.
+describe("discardStreamBody", () => {
+  it("destroys a readable stream body", () => {
+    const stream = Readable.from(["chunk"]);
+    expect(stream.destroyed).to.be.false;
+
+    discardStreamBody(stream);
+
+    expect(stream.destroyed).to.be.true;
+  });
+
+  it("is idempotent on an already destroyed stream", () => {
+    // The SDK drains error bodies itself via `loadResult` on the `throwOn` path,
+    // so a body reaching here may already be finished.
+    const stream = Readable.from(["chunk"]);
+    stream.destroy();
+
+    expect(() => discardStreamBody(stream)).to.not.throw();
+    expect(stream.destroyed).to.be.true;
+  });
+
+  it("leaves a string body intact for callers that parse it afterwards", () => {
+    // `transformation-service` discards before reading the 401 message; that is
+    // only safe because a `callAsJson` string body has no `destroy`.
+    const body = JSON.stringify({ message: "Authorization has been denied" });
+
+    discardStreamBody(body);
+
+    expect((JSON.parse(body) as { message: string }).message).to.equal("Authorization has been denied");
+  });
+
+  it("ignores a Blob-like body with no destroy method", () => {
+    expect(() => discardStreamBody({ size: 12, type: "application/zip" })).to.not.throw();
+  });
+
+  it("ignores undefined and null bodies", () => {
+    expect(() => discardStreamBody(undefined)).to.not.throw();
+    expect(() => discardStreamBody(null)).to.not.throw();
+  });
+
+  it("ignores a destroy property that is not callable", () => {
+    expect(() => discardStreamBody({ destroy: "not a function" })).to.not.throw();
+  });
+});


### PR DESCRIPTION
## The [issue](https://github.com/apimatic/apimatic-cli/issues/301)

`portal toc new` treated *every* failure to extract endpoint data as a reason to fall back to the default TOC:

```ts
if (result.isErr()) {
  this.prompts.fallingBackToDefault();
  return TocComponents.empty();
}
```

`TocComponents.empty()` means "no Endpoints, Events or Models sections". So when a user was logged out — or hit a network error, an expired key, or an invalid spec — the command would:

1. Write a `toc.yml` containing only custom content, **overwriting a possibly valid existing TOC**,
2. Report success, giving no indication that the endpoint sections were dropped, and
3. **Hang** instead of returning to the shell.

## The fix

### 1. Propagate the error instead of silently degrading

`actions/portal/toc/new-toc.ts`

The extraction block now returns `Result<TocComponents, ServiceError>`. A failed extraction returns `err(...)`; the caller reports the reason (auth, network, invalid spec) and returns `ActionResult.failed()`, leaving `toc.yml` untouched. `specFileStream.close()` moved into a `finally` so it is released on both paths.

### 2. Require a `spec/` directory

`actions/portal/toc/new-toc.ts`, `prompts/portal/toc/new-toc.ts`

The spec is what the TOC is built from, and the next step — portal generation — needs it regardless, so a TOC generated without one only defers the failure to a later command. The default-TOC fallback is dropped entirely: the command now fails when the spec is unusable, whether or not any `--expand-*` flag was passed.

Missing and empty are reported separately. `SpecContext.validate()` treats both as invalid, but only one of them is fixed by adding files to a directory that already exists. Both messages name the build directory, since that is the path the user passed.

Auth is deliberately not part of this check: with no spec no request is made, so an unauthorized message here would name a cause that did not occur. A logged-out user is blocked on the spec first, and on auth once a spec exists.

This removes `TocComponents.empty()` and the `fallingBackToDefault` prompt, both now unreachable.

### 3. Release stream error bodies

`utils/utils.ts`, `infrastructure/service-error.ts`, `infrastructure/services/transformation-service.ts`

The hang had a separate cause. `generateTocData` is a `callAsStream` endpoint, so on failure the SDK hands back an undrained `IncomingMessage` on `ApiError.body`. Its socket stays open and keeps the Node event loop alive, and since `outro()` only sets `process.exitCode` — we never call `process.exit()` — the process printed its outro and then sat there.

This is narrower than "stream endpoints leak their error bodies". `@apimatic/core` normally drains them itself: `loadResult` reads the body into `error.result` before the error is thrown. But it only runs on the `throwOn` path, and only `if (errorConstructor.prototype instanceof ApiError)` — strict subclasses. Two gaps follow:

- **No matching `throwOn`** — the generic response validator throws a bare `ApiError` with no `loadResult` call at all.
- **`throwOn` registered with `ApiError` itself** — fails the subclass check, so `loadResult` is skipped.

`tableOfContentsController` and `transformationController` register **zero** `throwOn`s, so every error from `generateTocData` and `downloadTransformedFile` lands in the first gap with a live stream body. That is the leak.

New `discardStreamBody(body)` in `utils/utils.ts`, alongside its counterpart `parseStreamBodyToJson`. `destroy()` is not declared on `NodeJS.ReadableStream` — it lives on `stream.Readable`/`IncomingMessage` — so narrowing the `string | Blob | NodeJS.ReadableStream` union still will not let us call it; an `isDestroyable` type guard probes for the method instead. That probe is a real platform branch, not defensiveness: the axios adapter yields a stream on Node and a Blob elsewhere.

Call sites:

- `service-error.ts` — from `handleServiceError`, covering `generateTocData`.
- `transformation-service.ts` — covering `downloadTransformedFile`.

Not applied where it would be wrong or redundant:

- **`PortalService.generatePortal`'s 422 path** returns `error.body` as the validation report and short-circuits before `handleServiceError`, so that stream is never destroyed. This is load-bearing rather than incidental: the SDK registers `throwOn(422, ApiError)` — `ApiError` itself, not a subclass — which is the second gap above, and the only reason the body arrives readable.
- **`validation-service.ts`** uses `validateApiViaFileV2`, a `callAsJson` endpoint with subclass `throwOn`s. Its body is always a string, so the call would be dead code.

### 4. Renamed prompt method

`PortalNewTocPrompts.logError` → `tocExtractionFailed`, to name what it reports.

## Tests

`test/utils/utils.test.ts` covers `discardStreamBody`. Its whole contract is a duck-type probe over a `string | Blob | NodeJS.ReadableStream` union, so the branches are the thing worth pinning: destroys a stream, leaves a string readable for the caller that parses it afterwards, ignores a Blob-like body, and stays quiet on an already-destroyed stream — the SDK drains error bodies itself on the `throwOn` path, so a finished body can reach it.

`test/actions/portal/toc/new-toc.test.ts` covers the spec requirement: missing, empty, and dotfiles-only, which `FileService.directoryEmpty` also treats as empty. All three return before any request is made, so no service stubbing is needed. A fourth asserts nothing is written to the build directory — the regression that mattered, since the old fallback overwrote a possibly valid `toc.yml` and exited 0.

Suite is green: 55 passing, 11 pending (the pre-existing skipped live-integration tests in `portal/generate.test.ts`).

## Behavior changes

Both are limited to `portal toc new`. `PortalNewTocAction` is only used by `commands/portal/toc/new.ts`, so nothing else is affected.

- **A failed extraction now fails the command** rather than writing a partial TOC — including when the user is logged out. Previously it exited 0 with a degraded file.
- **A missing or empty `spec/` directory now fails the command.** Previously a build without `spec/` produced the default TOC and exited 0.
