### PR TITLE
docs: add branching and comment conventions to .ai/instructions.md

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -67,7 +67,18 @@ Supporting: **Types** (`src/types/`) for value objects, context objects, and dom
 - **Commands use `export default class`** — oclif requires default export; actions, prompts, and services use named exports (`export class`)
 - **Static fields use `readonly`** — `static readonly summary`, `static readonly description`, `static readonly cmdTxt` on every Command
 - **Topic separator is space** — `apimatic portal generate`, not `apimatic portal:generate`
+- **No AI-generated comments** — comment only to explain non-obvious *why*: a constraint, a workaround, a subtle invariant. Never restate what the code already says, narrate a change, or leave notes addressed to a future agent. Default to no comment; existing comment density in nearby code is never a reason to add more.
 - **Telemetry** — After `outro(result)`, commands optionally track failures via `result.mapAll(() => {}, async () => { await new TelemetryService(configDir).trackEvent(new SomeFailedEvent(...), shell) }, () => {})`. Event classes extend `DomainEvent` (`src/types/events/`). Only the failure callback is populated; success/cancel are no-ops.
+
+## Branching
+
+Always start work from `dev` — never from `main`. This applies to branches and worktrees alike.
+
+- Make sure `dev` is current (`git fetch origin dev`) and branch from `origin/dev`.
+- Open pull requests against `dev`.
+- Never commit to, branch from, or target `main` directly. If a task appears to require it, stop and ask.
+
+**Worktrees** — a new worktree starts from this repo's default branch, `beta`, so move it onto `dev` before making any changes: `git fetch origin dev && git reset --hard origin/dev` (fresh, clean worktrees only). Confirm with `git log --oneline -1` that HEAD matches the `origin/dev` tip.
 
 ## Commit Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,15 @@ git reset --hard origin/dev   # only in a fresh, clean worktree
 
 Then confirm with `git log --oneline -1` that HEAD matches the `origin/dev` tip. Branch names and PRs from a worktree follow the same rules as above: cut from `origin/dev`, target `dev`.
 
+## Comments
+
+AI-generated comments are not allowed.
+
+- Do not add comments that restate what the code already says.
+- Do not narrate a change, leave notes for a future agent, or address the reader as an AI.
+- Comment only to explain non-obvious *why*: a constraint, a workaround, a subtle invariant.
+- Default to no comment. Do not add comments because nearby code has them — existing comment density is never a reason to add more.
+
 ## Skills
 
 Reference these files as needed for scaffolding:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,9 @@ Always start work from `dev` — never from `main`. This applies to branches and
 
 ### Worktrees
 
-A new worktree does **not** start from `dev` by default — it starts from this repo's default branch, which is `beta`. Re-base it onto `dev` before making any changes:
+Base every worktree on `origin/dev` too.
+
+Be aware that a new worktree starts from this repo's default branch, `beta`. Always move it onto `dev` before making any changes:
 
 ```sh
 git fetch origin dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,37 +2,7 @@
 
 This file provides guidance to Claude Code when working in this repository.
 
-Read `.ai/instructions.md` for full project instructions (architecture, conventions, testing, commits).
-
-## Branching
-
-Always start work from `dev` — never from `main`. This applies to branches and worktrees alike.
-
-- Before creating a branch, make sure `dev` is current (`git fetch origin dev`) and branch from `origin/dev`.
-- Open pull requests against `dev`.
-- Never commit to, branch from, or target `main` directly. If a task appears to require it, stop and ask.
-
-### Worktrees
-
-Base every worktree on `origin/dev` too.
-
-Be aware that a new worktree starts from this repo's default branch, `beta`. Always move it onto `dev` before making any changes:
-
-```sh
-git fetch origin dev
-git reset --hard origin/dev   # only in a fresh, clean worktree
-```
-
-Then confirm with `git log --oneline -1` that HEAD matches the `origin/dev` tip. Branch names and PRs from a worktree follow the same rules as above: cut from `origin/dev`, target `dev`.
-
-## Comments
-
-AI-generated comments are not allowed.
-
-- Do not add comments that restate what the code already says.
-- Do not narrate a change, leave notes for a future agent, or address the reader as an AI.
-- Comment only to explain non-obvious *why*: a constraint, a workaround, a subtle invariant.
-- Default to no comment. Do not add comments because nearby code has them — existing comment density is never a reason to add more.
+Read `.ai/instructions.md` for full project instructions (architecture, conventions, branching, testing, commits).
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,14 @@ This file provides guidance to Claude Code when working in this repository.
 
 Read `.ai/instructions.md` for full project instructions (architecture, conventions, testing, commits).
 
+## Branching
+
+Always start work from `dev` — never from `main`.
+
+- Before creating a branch, make sure `dev` is current (`git fetch origin dev`) and branch from `origin/dev`.
+- Open pull requests against `dev`.
+- Never commit to, branch from, or target `main` directly. If a task appears to require it, stop and ask.
+
 ## Skills
 
 Reference these files as needed for scaffolding:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,22 @@ Read `.ai/instructions.md` for full project instructions (architecture, conventi
 
 ## Branching
 
-Always start work from `dev` — never from `main`.
+Always start work from `dev` — never from `main`. This applies to branches and worktrees alike.
 
 - Before creating a branch, make sure `dev` is current (`git fetch origin dev`) and branch from `origin/dev`.
 - Open pull requests against `dev`.
 - Never commit to, branch from, or target `main` directly. If a task appears to require it, stop and ask.
+
+### Worktrees
+
+A new worktree does **not** start from `dev` by default — it starts from this repo's default branch, which is `beta`. Re-base it onto `dev` before making any changes:
+
+```sh
+git fetch origin dev
+git reset --hard origin/dev   # only in a fresh, clean worktree
+```
+
+Then confirm with `git log --oneline -1` that HEAD matches the `origin/dev` tip. Branch names and PRs from a worktree follow the same rules as above: cut from `origin/dev`, target `dev`.
 
 ## Skills
 


### PR DESCRIPTION
Adds two project conventions to `.ai/instructions.md`, where this repo keeps its conventions (`CLAUDE.md` only points to that file).

## Branching

New `## Branching` section, placed before `## Commit Conventions`:

- Always start work from `dev`, never `main` — branch from `origin/dev`, open PRs against `dev`.
- Never commit to, branch from, or target `main`; stop and ask if a task appears to require it.
- Worktrees included, with a re-base recipe.

The worktree note exists because this repo's remote default branch is `beta` (`refs/remotes/origin/HEAD` -> `origin/beta`), not `main` or `dev`, and the three have diverged. A newly created worktree therefore starts from `beta`, so the section gives `git fetch origin dev && git reset --hard origin/dev` (fresh, clean worktrees only) plus a verification step.

## Comments

New bullet in `## Critical Code Conventions`: **No AI-generated comments** — comment only to explain non-obvious *why* (a constraint, workaround, or subtle invariant); never restate the code, narrate a change, or leave notes for a future agent. Default to no comment; existing comment density nearby is never a reason to add more.

## CLAUDE.md

Unchanged except one word: its pointer line now reads "architecture, conventions, **branching**, testing, commits" so the new section is discoverable.

## Notes for reviewers

- The branching rule routes everything to `dev` as requested and deliberately says nothing about targeting `beta`. If `beta` is in practice the integration branch, this rule and the repo default disagree, and the remote default may want repointing.
- The comment rule covers code comments only. It does not address AI attribution trailers in commit messages or PR bodies; say so if those should be banned too.
- Branch history: earlier commits put these rules in `CLAUDE.md` before `ec02bb9` moved them here. Net diff against `dev` is +11 lines in `.ai/instructions.md` and 1 changed line in `CLAUDE.md`. Worth squashing on merge.

Docs-only change; no code touched.