### PR TITLE
test: call the renamed CodegenOption factory

### DIFF
--- a/test/prompts/sdk/generate.test.ts
+++ b/test/prompts/sdk/generate.test.ts
@@ -4,7 +4,7 @@ import { log } from "@clack/prompts";
 import { SdkGeneratePrompts } from "../../../src/prompts/sdk/generate.js";
 import { CodeGenerationVersion, CodegenOption, Stability } from "../../../src/types/sdk/generate.js";
 
-const v4 = CodegenOption.resolve(CodeGenerationVersion.V4, Stability.BETA);
+const v4 = CodegenOption.create(CodeGenerationVersion.V4, Stability.BETA);
 
 describe("SdkGeneratePrompts.warnIfStabilityIgnored", () => {
   const prompts = new SdkGeneratePrompts();

--- a/test/prompts/sdk/publish/publishing-details.test.ts
+++ b/test/prompts/sdk/publish/publishing-details.test.ts
@@ -36,7 +36,7 @@ describe("formatPublishingDetails", () => {
   it("names the generator once it is no longer the default", () => {
     const output = details(
       [PublishType.PackagePublishing],
-      CodegenOption.resolve(CodeGenerationVersion.V4, Stability.BETA)
+      CodegenOption.create(CodeGenerationVersion.V4, Stability.BETA)
     );
 
     expect(output).to.contain("Generator: V4 (beta)");
@@ -45,7 +45,7 @@ describe("formatPublishingDetails", () => {
   it("reports v3 as stable even when beta was requested", () => {
     const output = details(
       [PublishType.PackagePublishing],
-      CodegenOption.resolve(CodeGenerationVersion.V3, Stability.BETA)
+      CodegenOption.create(CodeGenerationVersion.V3, Stability.BETA)
     );
 
     expect(output).to.contain("Generator: V3 (stable)");


### PR DESCRIPTION
## Problem

`pnpm test` aborts before running a single suite:

```
Exception during run: TypeError: CodegenOption.resolve is not a function
    at test/prompts/sdk/generate.test.ts:7:26
```

`refactor: rename factory method` (69931ee) renamed `CodegenOption.resolve` to `CodegenOption.create` across `src/`, but three call sites in the prompt tests were left behind. Two of them sit at module scope, so the missing method throws while mocha is still loading test files — that's a load-time failure, not a test failure, so it takes down the **whole** run rather than just the two affected suites.

## Fix

Point the three stale call sites at `create`. No production code changes; `create` is already the only factory `src/` uses.

## Verification

On `dev` before the change, the suite aborts at load with the error above. After:

```
131 passing (2s)
11 pending
```

- `npx tsc -b` — clean
- `npx eslint . --ext .ts` — clean
- Both previously-dead suites now execute and pass: `SdkGeneratePrompts.warnIfStabilityIgnored` (3) and `formatPublishingDetails` (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)