### PR TITLE
fix: clarify CLI messages for plugin generation and publishing setup

### DIFF
--- a/src/infrastructure/services/plugin-service.ts
+++ b/src/infrastructure/services/plugin-service.ts
@@ -16,7 +16,8 @@ import { envInfo } from '../env-info.js';
 import {
   GENERATION_TIMEOUT_MS,
   pollUntilCompleted,
-  STATUS_POLL_INTERVAL_MS
+  STATUS_POLL_INTERVAL_MS,
+  ValidationErrorFormatter
 } from '../generation-status-poller.js';
 import { FileService } from '../file-service.js';
 import { mapRequestError, mapTransportError, ServiceError } from '../service-error.js';
@@ -62,7 +63,8 @@ export class PluginService {
     const completed = await pollUntilCompleted({
       pollIntervalMs: this.timings.pollIntervalMs,
       fetchStatus: () => this.getGenerationStatus(generationId, commandMetadata.shell, token),
-      timeout: { budgetMs: this.timings.generationTimeoutMs, label: 'Plugin generation' }
+      timeout: { budgetMs: this.timings.generationTimeoutMs, label: 'Plugin generation' },
+      formatValidationError: formatPluginValidationError
     });
     if (completed.isErr()) {
       return err(completed.error);
@@ -167,3 +169,21 @@ export class PluginService {
   }
 }
 
+const formatPluginValidationError: ValidationErrorFormatter = (errors) => {
+  const messages = Object.entries(errors).flatMap(([path, pathMessages]) =>
+    pathMessages.map((message) => qualify(path, message))
+  );
+  return 'One or more validation errors occurred.' + (messages.length ? '\n- ' + messages.join('\n- ') : '');
+};
+
+const qualify = (path: string, message: string): string => {
+  if (!path) return message;
+
+  const quotedProperty = message.match(/^'([^']+)'/);
+  const property = quotedProperty?.[1];
+  if (property && (path === property || path.endsWith(`.${property}`))) {
+    return `'${path}'${message.slice(quotedProperty[0].length)}`;
+  }
+
+  return `${path}: ${message}`;
+};

--- a/src/infrastructure/services/plugin-service.ts
+++ b/src/infrastructure/services/plugin-service.ts
@@ -179,7 +179,7 @@ const formatPluginValidationError: ValidationErrorFormatter = (errors) => {
 const qualify = (path: string, message: string): string => {
   if (!path) return message;
 
-  const quotedProperty = message.match(/^'([^']+)'/);
+  const quotedProperty = /^'([^']+)'/.exec(message);
   const property = quotedProperty?.[1];
   if (property && (path === property || path.endsWith(`.${property}`))) {
     return `'${path}'${message.slice(quotedProperty[0].length)}`;

--- a/src/prompts/format.ts
+++ b/src/prompts/format.ts
@@ -1,20 +1,21 @@
-import pc from "picocolors";
+import pc from 'picocolors';
 import { intro as i, outro as o } from '@clack/prompts';
-import { ActionResult } from "../actions/action-result.js";
-import { DirectoryPath } from "../types/file/directoryPath.js";
-import { FilePath } from "../types/file/filePath.js";
+import { ActionResult } from '../actions/action-result.js';
+import { DirectoryPath } from '../types/file/directoryPath.js';
+import { FilePath } from '../types/file/filePath.js';
 
 export const format = {
   // Core element types
   var: (text: string) => pc.magenta(`'${text}'`),
   path: (text: DirectoryPath | FilePath) => pc.cyan(`'${text}'`),
-  cmd: (cmd: string, ...args: string[]) => `${pc.blueBright(cmd)} ${args.map(arg => pc.dim(arg)).join(" ")}`,
-  cmdAlt: (cmd: string, ...args: string[]) => `${pc.dim(pc.blueBright(cmd))} ${args.map(arg => pc.blueBright(arg)).join(" ")}`,
+  cmd: (cmd: string, ...args: string[]) => `${pc.blueBright(cmd)} ${args.map((arg) => pc.dim(arg)).join(' ')}`,
+  cmdAlt: (cmd: string, ...args: string[]) =>
+    `${pc.dim(pc.blueBright(cmd))} ${args.map((arg) => pc.blueBright(arg)).join(' ')}`,
   link: (text: string) => pc.underline(pc.blueBright(text)),
   description: (text: string) => pc.greenBright(`${text}`),
   flag: (name: string, value: string | undefined = undefined) => {
     if (value) {
-      const sanitizedValue = value.includes(" ") ? `'${value}'` : value;
+      const sanitizedValue = value.includes(' ') ? `'${value}'` : value;
       return `${pc.green(`--${name}`)}=${pc.dim(sanitizedValue)}`;
     }
     return `${pc.green(`--${name}`)}`;
@@ -28,7 +29,7 @@ export const format = {
   intro: (text: string) => pc.bgCyan(text),
   outroSuccess: (text: string) => pc.bgGreen(text),
   outroFailure: (text: string) => pc.bgRed(text),
-  outroCancelled: (text: string) => pc.bgWhite(pc.blackBright(text)),
+  outroCancelled: (text: string) => pc.bgWhite(pc.blackBright(text))
 };
 
 export function intro(text: string) {
@@ -37,7 +38,7 @@ export function intro(text: string) {
 export function outro<T>(result: ActionResult<T>) {
   const exitCode = result.getExitCode();
   const message = result.getMessage();
-  
+
   const outroMessage = result.mapAll(
     () => format.outroSuccess(message),
     () => format.outroFailure(message),
@@ -57,19 +58,15 @@ export interface TreeNode extends LeafNode {
   items: Array<TreeNode | LeafNode>;
 }
 
-export function getTree(
-  dir: TreeNode,
-  prefix: string = "",
-  isLast: boolean = true
-): string {
-  const pointer = isLast ? "└─ " : "├─ ";
+export function getTree(dir: TreeNode, prefix: string = '', isLast: boolean = true): string {
+  const pointer = isLast ? '└─ ' : '├─ ';
   const folderName = dir.name;
-  const description = dir.description ? format.description(dir.description) : "";
+  const description = dir.description ? format.description(dir.description) : '';
 
-  let output = `${prefix}${pointer}${folderName}${description ? " " + description : ""}\n`;
+  let output = `${prefix}${pointer}${folderName}${description ? ' ' + description : ''}\n`;
 
   const items = dir.items;
-  const newPrefix = prefix + (isLast ? "   " : "|  ");
+  const newPrefix = prefix + (isLast ? '   ' : '|  ');
 
   items.forEach((item, index) => {
     const last = index === items.length - 1;
@@ -77,10 +74,10 @@ export function getTree(
     if ('items' in item) {
       output += getTree(item as TreeNode, newPrefix, last);
     } else {
-      const filePointer = last ? "└─ " : "├─ ";
+      const filePointer = last ? '└─ ' : '├─ ';
       const fileName = item.name;
-      const fileDescription = item.description ? format.description(item.description) : "";
-      output += `${newPrefix}${filePointer}${fileName}${fileDescription ? " " + fileDescription : ""}\n`;
+      const fileDescription = item.description ? format.description(item.description) : '';
+      output += `${newPrefix}${filePointer}${fileName}${fileDescription ? ' ' + fileDescription : ''}\n`;
     }
   });
 

--- a/src/prompts/format.ts
+++ b/src/prompts/format.ts
@@ -21,6 +21,8 @@ export const format = {
     return `${pc.green(`--${name}`)}`;
   },
 
+  continuation: (text: string) => `\n${pc.gray('│')}  ${text}`,
+
   // Common message styles
   success: (text: string) => pc.green(text),
   error: (text: string) => pc.red(text),

--- a/src/prompts/plugin/generate.ts
+++ b/src/prompts/plugin/generate.ts
@@ -57,13 +57,13 @@ export class PluginGeneratePrompts {
   }
 
   public noPublishedSdks() {
-    log.info(`${f.var(PLUGIN_CONFIG_FILE)} has no published SDKs yet.`);
+    log.info(`${f.var(PLUGIN_CONFIG_FILE)} has no published SDKs config yet.`);
   }
 
   public nextStepsPublishSdks() {
     const message =
-      `Publish an SDK for each language you want in the plugin, and include ${f.var('Source Code')} ` +
-      `publishing.\n\n` +
+      `Publish SDK for the language(s) to add it to plugin-config.json. ` +
+      `${f.var('Source Code')} details are required.\n\n` +
       `Run '${f.cmdAlt('apimatic', 'sdk', 'publish')}'\n\n` +
       `Then run '${f.cmdAlt('apimatic', 'plugin', 'generate')}'.`;
     noteWrapped(message, 'Next Steps');

--- a/src/prompts/publishing/profile/list.ts
+++ b/src/prompts/publishing/profile/list.ts
@@ -6,6 +6,10 @@ import {
   PublishingProfileItem
 } from '../../../types/publish-api/publishing-profile-item.js';
 import { buildTableWithHeading, withSpinner } from '../../prompt.js';
+import { format as f } from '../../format.js';
+
+const sourceCodePublishingUrl = 'https://docs.apimatic.io/generate-sdks/publish-sdk-to-github/';
+const packagePublishingUrl = 'https://docs.apimatic.io/generate-sdks/sdk-publishing/configure-sdk-publishing/';
 
 export class PublishingProfileListPrompts {
   public fetchProfiles(fn: Promise<Result<PublishingProfileItem[], ServiceError>>) {
@@ -22,7 +26,11 @@ export class PublishingProfileListPrompts {
   }
 
   public noProfilesFound() {
-    log.info('No publishing profiles found. Please create a publishing profile on the APIMatic App to view it here.');
+    log.info(
+      'No publishing profiles found. Please create a publishing profile on the APIMatic App to view it here.' +
+        `\n\nSource Code publishing: ${f.link(sourceCodePublishingUrl)}` +
+        `\nPackage publishing: ${f.link(packagePublishingUrl)}`
+    );
   }
 
   public displayProfiles(groups: PublishingProfileSummaryGroup[]) {

--- a/src/prompts/publishing/profile/list.ts
+++ b/src/prompts/publishing/profile/list.ts
@@ -1,7 +1,10 @@
 import { log } from '@clack/prompts';
 import { Result } from 'neverthrow';
 import { ServiceError } from '../../../infrastructure/service-error.js';
-import { PublishingProfileSummaryGroup, PublishingProfileItem } from '../../../types/publish-api/publishing-profile-item.js';
+import {
+  PublishingProfileSummaryGroup,
+  PublishingProfileItem
+} from '../../../types/publish-api/publishing-profile-item.js';
 import { buildTableWithHeading, withSpinner } from '../../prompt.js';
 
 export class PublishingProfileListPrompts {
@@ -30,9 +33,15 @@ export class PublishingProfileListPrompts {
       rows: group.profiles.map((profile) => [
         profile.name,
         profile.id,
-        profile.enabledLanguages.length === 0 ? '—' : profile.enabledLanguages.join(', '),
-      ]),
+        profile.enabledLanguages.length === 0 ? '—' : profile.enabledLanguages.join(', ')
+      ])
     }));
-    log.info(`Publishing Profiles (${label})\n\n${buildTableWithHeading(tableGroups, ['Name', 'ID', 'Languages'], ['primary', 'secondary', 'item'])}`);
+    log.info(
+      `Publishing Profiles (${label})\n\n${buildTableWithHeading(
+        tableGroups,
+        ['Name', 'ID', 'Languages'],
+        ['primary', 'secondary', 'item']
+      )}`
+    );
   }
 }

--- a/src/prompts/sdk/publish/interactive.ts
+++ b/src/prompts/sdk/publish/interactive.ts
@@ -39,7 +39,9 @@ export class SdkPublishInteractivePrompts {
 
   public srcDirectoryInvalid(directory: DirectoryPath) {
     log.error(
-      `${f.path(directory)} does not contain a valid ${f.var('APIMATIC-BUILD.json')}. Please check the path and try again.`
+      `${f.path(directory)} does not contain a valid ${f.var(
+        'APIMATIC-BUILD.json'
+      )}. Please check the path and try again.`
     );
   }
 

--- a/src/prompts/sdk/publish/interactive.ts
+++ b/src/prompts/sdk/publish/interactive.ts
@@ -197,8 +197,8 @@ export class SdkPublishInteractivePrompts {
 
   public async confirmRecordSdk(): Promise<boolean> {
     const message =
-      `Update configuration for context plugin generation?\n` +
-      `See '${f.cmdAlt('apimatic', 'plugin', 'generate')} ${f.flag('help')}' for more information.`;
+      `Update configuration for context plugin generation?` +
+      f.continuation(`See '${f.cmdAlt('apimatic', 'plugin', 'generate')} ${f.flag('help')}' for more information.`);
 
     const record = await confirm({ message, initialValue: true });
     if (isCancel(record)) return false;

--- a/test/infrastructure/services/plugin-service.test.ts
+++ b/test/infrastructure/services/plugin-service.test.ts
@@ -216,6 +216,77 @@ describe('PluginService', () => {
       expect(error.getError('languages')).to.deep.equal(['no language in languages can be built by this generator']);
     });
 
+    it('qualifies each message with the config path the API keyed it by', async () => {
+      respondToStatus = statusBody({
+        status: 'ValidationError',
+        errors: { 'languages.php.source': ["'source' is required"] }
+      });
+
+      const error = errorFrom(await generatePlugin());
+
+      expect(error.errorMessage).to.equal(
+        "One or more validation errors occurred.\n- 'languages.php.source' is required"
+      );
+    });
+
+    it('tells two languages reporting the same property apart', async () => {
+      respondToStatus = statusBody({
+        status: 'ValidationError',
+        errors: {
+          'languages.csharp.package.version': ["'package.version' is required"],
+          'languages.java.package.version': ["'package.version' is required"]
+        }
+      });
+
+      const error = errorFrom(await generatePlugin());
+
+      expect(error.errorMessage).to.equal(
+        'One or more validation errors occurred.' +
+          "\n- 'languages.csharp.package.version' is required" +
+          "\n- 'languages.java.package.version' is required"
+      );
+    });
+
+    it('keeps the path ahead of a message that names no property', async () => {
+      respondToStatus = statusBody({
+        status: 'ValidationError',
+        errors: { languages: ['no language in languages can be built by this generator'] }
+      });
+
+      const error = errorFrom(await generatePlugin());
+
+      expect(error.errorMessage).to.equal(
+        'One or more validation errors occurred.' +
+          '\n- languages: no language in languages can be built by this generator'
+      );
+    });
+
+    it('leaves a message the API keyed to no property untouched', async () => {
+      respondToStatus = statusBody({
+        status: 'ValidationError',
+        errors: { '': ['Context plugin generation is not allowed on your subscription'] }
+      });
+
+      const error = errorFrom(await generatePlugin());
+
+      expect(error.errorMessage).to.equal(
+        'One or more validation errors occurred.\n- Context plugin generation is not allowed on your subscription'
+      );
+    });
+
+    it('does not re-qualify a property the API already spelled out in full', async () => {
+      respondToStatus = statusBody({
+        status: 'ValidationError',
+        errors: { pluginId: ["'pluginId' must be lower-case kebab-case."] }
+      });
+
+      const error = errorFrom(await generatePlugin());
+
+      expect(error.errorMessage).to.equal(
+        "One or more validation errors occurred.\n- 'pluginId' must be lower-case kebab-case."
+      );
+    });
+
     it('terminates on a validation error that carries no messages', async () => {
       respondToStatus = statusBody({ status: 'ValidationError' });
 


### PR DESCRIPTION
Four message and prompt fixes surfaced during a review pass, each in its own commit, with the pre-existing Prettier churn on the touched files quarantined into separate `style:` commits so the behaviour changes stay reviewable.

## Validation errors lost the property path

`formatValidationErrors` rendered `Object.values(errors).flat()`, discarding the map keys — which are the full `plugin-config.json` paths the API sends. With seven languages in a config, `'package.version' is required` was equally true of all of them.

```
before                              after
- 'package.version' is required     - 'languages.csharp.package.version' is required
- 'codegenVersion' is required      - 'languages.csharp.codegenVersion' is required
```

Where the quoted property is the tail of the key, the full path replaces it; anything else keeps the message verbatim behind its key. Plugin generation gets its own formatter via the `formatValidationError` hook the poller already exposed, rather than changing the shared one — portal and SDK generation key errors by request-shape paths their callers cannot act on, and their messages already name the language. The keyed map was already retained on the `ServiceError`; only the display string lost it.

5 new tests cover the multi-language case, the empty key, a message naming no property, and a key already identical to its property.

## Prompt continuation line fell outside the box

Clack interpolates a prompt message verbatim and applies the gutter to the first line only, so the newline in `confirmRecordSdk` dropped the help hint to column 0. Only `log.*` re-prefixes every line, which is why no other multi-line message in the prompts showed this. A `format.continuation()` helper now carries the gutter.

## Next steps did not say what was missing

`plugin generate` told the user to publish "an SDK for each language you want in the plugin" without naming the file the entries land in. Now points at `plugin-config.json` and names the Source Code details required.

## Empty profile list had no route forward

`publishing profile list` said to create a profile on the APIMatic App and left the user to find the setup docs. Now links both halves a profile configures — source code publishing and package publishing — via `format.link`.

## Verification

- `tsc --noEmit` clean, `eslint src test` clean
- 246 passing / 11 pending / 0 failing (241 before; +5 new)
- Each commit compiles and passes green independently
- Prettier reports no content differences on any touched file; the remaining `--check` failures are the repo-wide CRLF/`endOfLine` mismatch that untouched files share

## Not included

Deliberately left out, discussed but unresolved:

- `'source' is required` wording is the API's. `hasPublishedSdks()` accepts `source` **or** `package` while the API demands `source`, so a package-only config passes our pre-flight and fails after a full generation round-trip. Fixing it locally needs confirmation on whether the API requires `source` per language or just once.
- `plugin generate` still returns `ActionResult.success()` at `actions/plugin/generate.ts:74` when no SDKs are recorded, printing a green `Succeeded` and exit 0 after generating nothing. `ActionResult.stopped()` already exists unused for this; the exit-code choice (130 vs 1) needs a decision.
- `generation-status-poller.ts:63` still drops every SubscriptionError message past the first.
- `'Plugin Generation failed.'` has a stray capital G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
