### PR TITLE
perf: ship the oclif manifest so startup stops importing every command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,7 @@ test-destination/
 test-portal/
 /.idea/
 .github/copilot-instructions.md
+
+# Generated at pack/publish time by `oclif manifest`; must never be committed
+# or linger in a dev tree, or oclif serves a stale command list.
+oclif.manifest.json

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
-        "build": "rimraf lib tsconfig.tsbuildinfo && tsc",
-        "build:watch": "tsc --watch",
+        "build": "rimraf lib tsconfig.tsbuildinfo oclif.manifest.json && tsc",
+        "build:watch": "rimraf oclif.manifest.json && tsc --watch",
         "apimatic": "node ./bin/run.js",
-        "postpack": "rimraf oclif.manifest.json",
+        "prepack": "oclif manifest",
         "posttest": "eslint . --ext .ts",
         "prettier": "prettier \"src/**/*.{js,ts}\"",
         "format": "prettier --write \"src/**/*.{js,ts}\"",


### PR DESCRIPTION
## Problem

`package.json` had `postpack: rimraf oclif.manifest.json` but no matching `prepack`, so the manifest was **never generated** and the published package shipped without it.

Without a manifest, oclif has to `import()` every command module on every invocation just to discover the command list. That pulled in **460 ESM modules for `apimatic --version`** alone — 141 app files, plus execa (106), `@apimatic/sdk` (72) and axios (57). On a first run the OS file cache is cold and Defender scans each newly-written file, so those 460 reads cost tens of seconds. That is the slow first-install cold start users hit.

## Fix

- `prepack: oclif manifest` — generates the manifest for pack/publish. This is the actual fix.
- `postpack` removed, cleanup folded into `build` / `build:watch` instead. Deleting the manifest mid-pack made pnpm's own `files` stat race it (`ENOENT ... stat 'oclif.manifest.json'`), so `pnpm pack` exited 1 with a stack trace while still writing a correct tarball. Nothing deletes it during pack now, so there is nothing to trip over.
- Clearing it in `build` / `build:watch` is what keeps the dev footgun closed: a new command cannot reach `lib/` without a build, and that build wipes any lingering manifest so oclif rescans rather than serving a stale command list. `rimraf` is idempotent on missing paths, so this is safe when no manifest exists.
- `.gitignore` — the manifest now survives a pack, so it is ignored to keep it out of commits.

CI already runs `pnpm build` before `semantic-release`, so `lib/` exists when `prepack` fires on `npm publish`.

## Measured

Fresh `npm install` of the packed tarball into a clean tree each time:

| | cold first run | warm run | modules loaded for `--version` |
|---|---|---|---|
| before | 37,163 ms | 1,280 ms | 460 |
| after | 4,922 ms | 261 ms | 2 |

Roughly 8x faster cold, 5x warm. The win reproduced across three independent A/B runs.

## Verification

- `pnpm i && pnpm build && pnpm pack` exits 0, no stack trace
- tarball has 464 files including `package/oclif.manifest.json`; all 17 commands present in the manifest
- `git status` clean after a pack
- lingering manifest is cleared by `pnpm build`
- from the installed tarball: `auth status` hits the live API correctly, `plugin generate --help` and `plugin publish --help` render their flags
- `pnpm test`: 290 passing, 11 pending, 0 failing

## Known tradeoff

Because the manifest now survives a pack, running `pnpm pack` *while* `build:watch` is already running leaves a manifest the watch will not clear — adding a command in that window shows "command not found" until the next rebuild. Narrow and self-evident; judged better than a stack trace on every pack.

## Follow-ups (not in this PR)

Install is now the dominant cost (~25s, 242 packages, 30.4 MB):

- `src/infrastructure/service-error.ts` imports `@apimatic/sdk` eagerly for two `instanceof` checks, so every command touching any service still loads 72 SDK + 57 axios modules. The SDK exposes only `.` and `./metadata` — no error-only subpath — so this needs `ServiceError` decoupled from `ApiError`.
- `prettier`@2 is 10.9 MB and `isomorphic-git` 4.8 MB of the 30.4 MB; `livereload` → `ejs` → `jake` → `async` drags ~230 files of build-tool dead weight in for a `portal serve`-only feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
