### PR TITLE
fix: add docs link to publishing profile messages

### DIFF
--- a/src/actions/sdk/publish/interactive.ts
+++ b/src/actions/sdk/publish/interactive.ts
@@ -55,7 +55,7 @@ export class SdkPublishInteractiveAction {
     const publishingProfileItems = publishingProfilesResponse.value;
     const publishingProfilesResult = PublishingProfiles.create(publishingProfileItems);
     if (publishingProfilesResult.isErr()) {
-      this.prompts.noPublishingProfilesFound(publishingProfilesResult.error);
+      this.prompts.noPublishingProfilesFound();
       return ActionResult.failed();
     }
 

--- a/src/prompts/publishing/links.ts
+++ b/src/prompts/publishing/links.ts
@@ -1,2 +1,2 @@
 export const SDK_PUBLISHING_OVERVIEW_URL =
-  'https://docs.apimatic.io/generate-sdks/sdk-publishing/sdk-publishing-overview';
+  'https://docs.apimatic.io/generate-sdks/sdk-publishing/sdk-publishing-overview/';

--- a/src/prompts/publishing/links.ts
+++ b/src/prompts/publishing/links.ts
@@ -1,0 +1,2 @@
+export const SDK_PUBLISHING_OVERVIEW_URL =
+  'https://docs.apimatic.io/generate-sdks/sdk-publishing/sdk-publishing-overview';

--- a/src/prompts/publishing/profile/list.ts
+++ b/src/prompts/publishing/profile/list.ts
@@ -7,9 +7,7 @@ import {
 } from '../../../types/publish-api/publishing-profile-item.js';
 import { buildTableWithHeading, withSpinner } from '../../prompt.js';
 import { format as f } from '../../format.js';
-
-const sourceCodePublishingUrl = 'https://docs.apimatic.io/generate-sdks/publish-sdk-to-github/';
-const packagePublishingUrl = 'https://docs.apimatic.io/generate-sdks/sdk-publishing/configure-sdk-publishing/';
+import { SDK_PUBLISHING_OVERVIEW_URL } from '../links.js';
 
 export class PublishingProfileListPrompts {
   public fetchProfiles(fn: Promise<Result<PublishingProfileItem[], ServiceError>>) {
@@ -27,9 +25,9 @@ export class PublishingProfileListPrompts {
 
   public noProfilesFound() {
     log.info(
-      'No publishing profiles found. Please create a publishing profile on the APIMatic App to view it here.' +
-        `\n\nSource Code publishing: ${f.link(sourceCodePublishingUrl)}` +
-        `\nPackage publishing: ${f.link(packagePublishingUrl)}`
+      `No publishing profiles found. Please create a publishing profile on the APIMatic App to view it here.\n\nLearn more: ${f.link(
+        SDK_PUBLISHING_OVERVIEW_URL
+      )}`
     );
   }
 

--- a/src/prompts/sdk/publish/interactive.ts
+++ b/src/prompts/sdk/publish/interactive.ts
@@ -13,6 +13,7 @@ import { PublishingProfile } from '../../../types/publish/publishing-profile.js'
 import { CodegenOption, Language } from '../../../types/sdk/generate.js';
 import { SemVersion } from '../../../types/publish/version.js';
 import { removeQuotes } from '../../../utils/string-utils.js';
+import { SDK_PUBLISHING_OVERVIEW_URL } from '../../publishing/links.js';
 
 export class SdkPublishInteractivePrompts {
   public async inputWorkingDirectory(
@@ -84,8 +85,12 @@ export class SdkPublishInteractivePrompts {
     log.error(serviceError.errorMessage);
   }
 
-  public noPublishingProfilesFound(errorMessage: string) {
-    log.error(errorMessage);
+  public noPublishingProfilesFound() {
+    log.error(
+      `No publishing profiles found. Please create a publishing profile on the APIMatic App before publishing an SDK.\n\nLearn more: ${f.link(
+        SDK_PUBLISHING_OVERVIEW_URL
+      )}`
+    );
   }
 
   public noProfileWithEnabledLanguagesFound() {

--- a/src/prompts/sdk/publish/interactive.ts
+++ b/src/prompts/sdk/publish/interactive.ts
@@ -95,7 +95,9 @@ export class SdkPublishInteractivePrompts {
 
   public noProfileWithEnabledLanguagesFound() {
     log.error(
-      'No publishing profiles found with languages enabled for Source Code Publishing or Package Publishing. Please enable at least one language in a publishing profile before publishing an SDK.'
+      `No publishing profiles found with languages enabled for Source Code Publishing or Package Publishing. Please enable at least one language in a publishing profile before publishing an SDK.\n\nLearn more: ${f.link(
+        SDK_PUBLISHING_OVERVIEW_URL
+      )}`
     );
   }
 

--- a/src/prompts/sdk/publish/non-interactive.ts
+++ b/src/prompts/sdk/publish/non-interactive.ts
@@ -8,6 +8,7 @@ import { withSpinner } from '../../prompt.js';
 import { PublishingProfileItem } from '../../../types/publish-api/publishing-profile-item.js';
 import { ProfileId } from '../../../types/publish/profile-id.js';
 import { Language } from '../../../types/sdk/generate.js';
+import { SDK_PUBLISHING_OVERVIEW_URL } from '../../publishing/links.js';
 
 const PLUGIN_CONFIG_FILE = 'plugin-config.json';
 
@@ -57,13 +58,17 @@ export class SdkPublishNonInteractivePrompts {
 
   public publishingProfileNotFound(profileId: ProfileId) {
     log.error(
-      `Publishing profile with id '${profileId}' not found. Please check if the provided profile id is correct or create a new publishing profile on the APIMatic App.`
+      `Publishing profile with id '${profileId}' not found. Please check if the provided profile id is correct or create a new publishing profile on the APIMatic App.\n\nLearn more: ${f.link(
+        SDK_PUBLISHING_OVERVIEW_URL
+      )}`
     );
   }
 
   public languageNotConfiguredForProfile(language: Language) {
     log.error(
-      `No configuration found for '${language}' in the selected publishing profile. Please check the provided profile's configuration on the APIMatic App and try again.`
+      `No configuration found for '${language}' in the selected publishing profile. Please check the provided profile's configuration on the APIMatic App and try again.\n\nLearn more: ${f.link(
+        SDK_PUBLISHING_OVERVIEW_URL
+      )}`
     );
   }
 
@@ -73,7 +78,9 @@ export class SdkPublishNonInteractivePrompts {
       .join(' + ');
     const noun = publishTypes.length === 1 ? 'type' : 'types';
     log.error(
-      `Publish ${noun} '${types}' not found or not enabled for '${language}' in the selected publishing profile. Please check your profile configuration on the APIMatic App and try again.`
+      `Publish ${noun} '${types}' not found or not enabled for '${language}' in the selected publishing profile. Please check your profile configuration on the APIMatic App and try again.\n\nLearn more: ${f.link(
+        SDK_PUBLISHING_OVERVIEW_URL
+      )}`
     );
   }
 

--- a/src/types/publish/publishing-profiles.ts
+++ b/src/types/publish/publishing-profiles.ts
@@ -9,9 +9,9 @@ import { PublishingProfile } from './publishing-profile.js';
 export class PublishingProfiles {
   private constructor(private readonly items: PublishingProfile[]) {}
 
-  public static create(items: PublishingProfileItem[]): Result<PublishingProfiles, string> {
+  public static create(items: PublishingProfileItem[]): Result<PublishingProfiles, 'No publishing profiles found.'> {
     if (items.length === 0) {
-      return err('No publishing profiles found. Please create a publishing profile on the APIMatic App before publishing an SDK.');
+      return err('No publishing profiles found.');
     }
 
     return ok(new PublishingProfiles(items.map((item) => PublishingProfile.create(item))));


### PR DESCRIPTION
@
Six publishing-profile messages told the user to go create or fix a profile "on the APIMatic App" without ever giving them an address. Only `publishing/profile/list.ts` linked anything at all.

## Changes

- New `src/prompts/publishing/links.ts` exporting `SDK_PUBLISHING_OVERVIEW_URL`, so the docs link has one home instead of being retyped per prompt.
- Six messages now append `Learn more: <link>`, with the existing sentences left verbatim:
  - `publishing/profile/list.ts` `noProfilesFound()` — its two older URLs and both module-level consts are replaced by the single overview link
  - `sdk/publish/interactive.ts` `noPublishingProfilesFound()` and `noProfileWithEnabledLanguagesFound()`
  - `sdk/publish/non-interactive.ts` `publishingProfileNotFound()`, `languageNotConfiguredForProfile()`, `publishTypesNotAvailableForLanguage()`
- `PublishingProfiles.create()` no longer returns user-facing copy from the types layer; `noPublishingProfilesFound()` owns its own text and no longer takes a string.

## Notes

- `commands/sdk/publish.ts` and `commands/publishing/profile/list.ts` are deliberately untouched — their descriptions mention profiles but never send the user anywhere.
- `pnpm test` currently fails at its `posttest` step (`eslint . --ext .ts`) because it crawls stale checkouts under `.claude/worktrees/`. That is pre-existing and unrelated; mocha passes.

## Verification

- `tsc -b` clean
- `eslint "src/**/*.{js,ts}"` clean
- mocha: 290 passing, 11 pending, 0 failing
- Messages rendered from the compiled output to confirm the link and clack gutter render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@