### PR TITLE
fix: stop requiring APIMATIC-BUILD.json for plugin generate (#333)

### DIFF
--- a/src/actions/plugin/generate.ts
+++ b/src/actions/plugin/generate.ts
@@ -34,8 +34,8 @@ export class PluginGenerateAction {
     }
 
     const buildContext = new BuildContext(buildDirectory);
-    if (!(await buildContext.validate())) {
-      this.prompts.srcDirectoryEmpty(buildDirectory);
+    if (!(await buildContext.exists())) {
+      this.prompts.srcDirectoryDoesNotExist(buildDirectory);
       return ActionResult.failed();
     }
 

--- a/src/prompts/plugin/generate.ts
+++ b/src/prompts/plugin/generate.ts
@@ -33,8 +33,8 @@ export class PluginGeneratePrompts {
     log.error(message);
   }
 
-  public srcDirectoryEmpty(directory: DirectoryPath) {
-    const message = `The ${f.var('src')} directory is either empty or invalid: ${f.path(directory)}`;
+  public srcDirectoryDoesNotExist(directory: DirectoryPath) {
+    const message = `The ${f.var('src')} directory does not exist at the provided location: ${f.path(directory)}`;
     log.error(message);
   }
 

--- a/src/prompts/sdk/publish/interactive.ts
+++ b/src/prompts/sdk/publish/interactive.ts
@@ -38,14 +38,6 @@ export class SdkPublishInteractivePrompts {
     log.error('No input directory was provided.');
   }
 
-  public srcDirectoryInvalid(directory: DirectoryPath) {
-    log.error(
-      `${f.path(directory)} does not contain a valid ${f.var(
-        'APIMATIC-BUILD.json'
-      )}. Please check the path and try again.`
-    );
-  }
-
   public async inputSdkDirectory(
     defaultDirectory: DirectoryPath,
     validator: (value: string | undefined) => string | Error | undefined

--- a/test/actions/plugin/generate.test.ts
+++ b/test/actions/plugin/generate.test.ts
@@ -81,12 +81,20 @@ describe('PluginGenerateAction', () => {
       expect(generatePlugin.called).to.be.false;
     });
 
-    it('fails when the build directory has no APIMATIC-BUILD.json', async () => {
+    it('fails when the src directory does not exist', async () => {
       const generatePlugin = sinon.stub(PluginService.prototype, 'generatePlugin');
-      await fsExtra.remove(path.join(buildDirectory, 'APIMATIC-BUILD.json'));
+      await fsExtra.remove(buildDirectory);
 
       expect((await execute()).isFailed()).to.be.true;
       expect(generatePlugin.called).to.be.false;
+    });
+
+    it('generates without an APIMATIC-BUILD.json, which only portal and v3 SDK builds need', async () => {
+      const generatePlugin = generated();
+      await fsExtra.remove(path.join(buildDirectory, 'APIMATIC-BUILD.json'));
+
+      expect((await execute()).isSuccess()).to.be.true;
+      expect(generatePlugin.called).to.be.true;
     });
   });
 


### PR DESCRIPTION
APIMATIC-BUILD.json describes a portal build, so it is meaningful for the portal commands and for v3 SDK generation. Plugin generation reads src/plugin-config.json and zips src/; it never reads the build config, yet it gated on BuildContext.validate(), which requires the file to exist.

A project that is SDK-only or plugin-only had to create a build file it has no other use for, and the failure named the wrong cause: src/ was reported as empty or invalid when it held exactly what the command documents it needs.

Gate on BuildContext.exists() instead. The directory check stays because a missing src/ would otherwise fall through to PluginRecordMetadataAction and create both the directory and a plugin-config.json the user never asked for.

Also drop SdkPublishInteractivePrompts.srcDirectoryInvalid. It is a build-file-specific message that was never called, and sdk publish correctly does not require the build file, so wiring it up would introduce the same bug.

Fixes #332