### PR TITLE
feat: offer typescript v4 codegen in interactive sdk publish

### DIFF
--- a/src/types/sdk/generate.ts
+++ b/src/types/sdk/generate.ts
@@ -99,7 +99,7 @@ export const CODEGEN_OPTIONS: Readonly<Record<Language, Readonly<NonEmptyArray<C
   [Language.PHP]: [CodegenOption.v3],
   [Language.PYTHON]: [CodegenOption.v3],
   [Language.RUBY]: [CodegenOption.v3],
-  [Language.TYPESCRIPT]: [CodegenOption.v3]
+  [Language.TYPESCRIPT]: [CodegenOption.v3, CodegenOption.create(CodeGenerationVersion.V4, Stability.BETA)]
 };
 
 export function getCodegenOptions(language: Language): Readonly<NonEmptyArray<CodegenOption>> {

--- a/test/actions/plugin/generate.test.ts
+++ b/test/actions/plugin/generate.test.ts
@@ -281,40 +281,4 @@ describe('PluginGenerateAction', () => {
       expect(pluginGenerationError.firstCall.args[0]).to.equal('One or more validation errors occurred.\n- a\n- b');
     });
   });
-
-  describe('code generator versions', () => {
-    // The CLI never inspects codegenVersion — the generator behind /plugin is what consumes it —
-    // so an entry must reach the service exactly as recorded, whatever version it names.
-    it('uploads a typescript v4 entry unchanged', async () => {
-      const typescript = {
-        source: { repositoryUrl: 'https://github.com/acme/acme-ts' },
-        package: { name: '@acme/payments', version: '1.2.3' },
-        codegenVersion: 'v4'
-      };
-      await fsExtra.writeJson(path.join(buildDirectory, 'plugin-config.json'), {
-        pluginId: 'acme-payments',
-        pluginName: 'Acme Payments',
-        pluginVersion: '0.1.0',
-        languages: { typescript }
-      });
-
-      // The temp directory holding the upload is cleaned up once the action returns, so the
-      // archive has to be read while the call is still in flight.
-      let uploaded: Buffer | undefined;
-      sinon.stub(PluginService.prototype, 'generatePlugin').callsFake(async (buildPath) => {
-        uploaded = await fsExtra.readFile(buildPath.toString());
-        return ok(Readable.from([pluginArchive]));
-      });
-
-      expect((await execute()).isSuccess()).to.be.true;
-
-      const uploadedZip = new FilePath(new DirectoryPath(tmpDirResult.path), new FileName('uploaded.zip'));
-      await fsExtra.writeFile(uploadedZip.toString(), uploaded!);
-      const unpacked = path.join(tmpDirResult.path, 'uploaded');
-      await new ZipService().unArchive(uploadedZip, new DirectoryPath(unpacked));
-
-      const config = fsExtra.readJsonSync(path.join(unpacked, 'plugin-config.json'));
-      expect(config.languages).to.deep.equal({ typescript });
-    });
-  });
 });

--- a/test/actions/plugin/generate.test.ts
+++ b/test/actions/plugin/generate.test.ts
@@ -281,4 +281,40 @@ describe('PluginGenerateAction', () => {
       expect(pluginGenerationError.firstCall.args[0]).to.equal('One or more validation errors occurred.\n- a\n- b');
     });
   });
+
+  describe('code generator versions', () => {
+    // The CLI never inspects codegenVersion — the generator behind /plugin is what consumes it —
+    // so an entry must reach the service exactly as recorded, whatever version it names.
+    it('uploads a typescript v4 entry unchanged', async () => {
+      const typescript = {
+        source: { repositoryUrl: 'https://github.com/acme/acme-ts' },
+        package: { name: '@acme/payments', version: '1.2.3' },
+        codegenVersion: 'v4'
+      };
+      await fsExtra.writeJson(path.join(buildDirectory, 'plugin-config.json'), {
+        pluginId: 'acme-payments',
+        pluginName: 'Acme Payments',
+        pluginVersion: '0.1.0',
+        languages: { typescript }
+      });
+
+      // The temp directory holding the upload is cleaned up once the action returns, so the
+      // archive has to be read while the call is still in flight.
+      let uploaded: Buffer | undefined;
+      sinon.stub(PluginService.prototype, 'generatePlugin').callsFake(async (buildPath) => {
+        uploaded = await fsExtra.readFile(buildPath.toString());
+        return ok(Readable.from([pluginArchive]));
+      });
+
+      expect((await execute()).isSuccess()).to.be.true;
+
+      const uploadedZip = new FilePath(new DirectoryPath(tmpDirResult.path), new FileName('uploaded.zip'));
+      await fsExtra.writeFile(uploadedZip.toString(), uploaded!);
+      const unpacked = path.join(tmpDirResult.path, 'uploaded');
+      await new ZipService().unArchive(uploadedZip, new DirectoryPath(unpacked));
+
+      const config = fsExtra.readJsonSync(path.join(unpacked, 'plugin-config.json'));
+      expect(config.languages).to.deep.equal({ typescript });
+    });
+  });
 });

--- a/test/types/sdk/generate.test.ts
+++ b/test/types/sdk/generate.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import {
+  CodeGenerationVersion,
+  CodegenOption,
+  getCodegenOptions,
+  Language,
+  Stability
+} from '../../../src/types/sdk/generate';
+
+const versionsOf = (language: Language) =>
+  getCodegenOptions(language).map((option) => option.codeGenerationVersion());
+
+describe('getCodegenOptions', () => {
+  it('offers V4 for typescript', () => {
+    expect(versionsOf(Language.TYPESCRIPT)).to.deep.equal([CodeGenerationVersion.V3, CodeGenerationVersion.V4]);
+  });
+
+  it('offers typescript V4 as beta', () => {
+    const v4 = getCodegenOptions(Language.TYPESCRIPT).find((option) => option.isV4());
+    expect(v4?.stabilityLevel()).to.equal(Stability.BETA);
+  });
+
+  it('lists V3 first so it stays the initial selection', () => {
+    for (const language of Object.values(Language)) {
+      expect(getCodegenOptions(language)[0], language).to.equal(CodegenOption.v3);
+    }
+  });
+});


### PR DESCRIPTION
## What

Registers `V4 (beta)` as a code generator option for TypeScript in `CODEGEN_OPTIONS`.

```diff
-  [Language.TYPESCRIPT]: [CodegenOption.v3]
+  [Language.TYPESCRIPT]: [CodegenOption.v3, CodegenOption.create(CodeGenerationVersion.V4, Stability.BETA)]
```

## Why

Enabling TypeScript V4 for context plugins comes down to letting a TypeScript SDK be published as V4 in the first place. Tracing the plugin path: `plugin generate` zips `src/` and uploads it with `plugin-config.json`, and neither `PluginGenerateAction` nor `PluginService` filters by language or codegen version. The `codegenVersion` on each language entry is whatever `sdk publish` recorded through `PluginRecordSdkAction`. `CODEGEN_OPTIONS` is the only CLI-side gate.

The interactive flow shows the picker only when a language has more than one option:

```ts
const codegenOptions = getCodegenOptions(language);
const codegenOption = codegenOptions.length === 1 ? codegenOptions[0]
  : await this.prompts.selectCodegenVersion(codegenOptions);
```

TypeScript had one, so an interactive publish was silently pinned to V3 and always wrote `codegenVersion: "v3"`. It now offers `V3 (stable)` / `V4 (beta)`, and the selection flows into both `generateV4Sdk` and the plugin-config entry.

Non-interactive `--language typescript --codegen-version v4 --stability beta` already parsed — validation there is server-side, as asserted by the existing test "does not filter languages by codegen version, leaving that to the service". Only the interactive path was gated.

Beta matches how C# V4 is registered today.

## Tests

Adds `test/types/sdk/generate.test.ts`:

- TypeScript offers V3 and V4
- TypeScript V4 is beta
- V3 stays first for every language, since the picker's `initialValue` is `options[0]`

Full suite: 294 passing, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
