### PR TITLE
feat: add Codex docs link to plugin try-it-locally note

### DIFF
--- a/src/prompts/plugin/generate.ts
+++ b/src/prompts/plugin/generate.ts
@@ -12,6 +12,7 @@ const PLUGIN_CONFIG_FILE = 'plugin-config.json';
 const CLAUDE_CODE_PLUGINS_URL = 'https://code.claude.com/docs/en/plugins#test-your-plugins-locally';
 const CURSOR_PLUGINS_URL = 'https://cursor.com/docs/plugins#test-plugins-locally';
 const VS_CODE_PLUGINS_URL = 'https://code.visualstudio.com/docs/agent-customization/agent-plugins#_use-local-plugins';
+const CODEX_PLUGINS_URL = 'https://developers.openai.com/plugins/build/plugins#install-a-local-plugin-manually';
 
 export class PluginGeneratePrompts {
   public generatePlugin(fn: Promise<Result<NodeJS.ReadableStream, ServiceError>>) {
@@ -88,7 +89,8 @@ export class PluginGeneratePrompts {
       `Load the plugin from ${f.path(plugin)} to try it before publishing.\n\n` +
       `${f.description('Claude Code')} ${f.link(CLAUDE_CODE_PLUGINS_URL)}\n` +
       `${f.description('Cursor')} ${f.link(CURSOR_PLUGINS_URL)}\n` +
-      `${f.description('VS Code')} ${f.link(VS_CODE_PLUGINS_URL)}`;
+      `${f.description('VS Code')} ${f.link(VS_CODE_PLUGINS_URL)}\n` +
+      `${f.description('Codex')} ${f.link(CODEX_PLUGINS_URL)}`;
     noteWrapped(message, 'Try It Locally');
   }
 


### PR DESCRIPTION
## Summary
- Adds an OpenAI Codex link to the "Try It Locally" note printed after `apimatic plugin generate`, alongside Claude Code, Cursor, and VS Code.
- Like the others, it points at the section covering manual install of a local (unpublished) plugin: https://developers.openai.com/plugins/build/plugins#install-a-local-plugin-manually

## Test plan
- `apimatic plugin generate` → the note now lists four assistants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8hdFjBckxfZ9xh6RD7sz9